### PR TITLE
dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,26 +20,20 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "castep-cell-io"
-version = "0.2.14"
+version = "0.2.16"
 dependencies = [
  "castep-periodic-table",
  "chemrust-core",
- "crystallographic-group",
+ "crystallographic-group 0.3.1",
  "nalgebra",
  "thiserror",
- "winnow",
+ "winnow 0.7.6",
 ]
 
 [[package]]
@@ -60,12 +54,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chemrust-core"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f81b3b15a33a9a509a303a286420e5fc04e6e522add5a1f8d2fae5cfa2c9f2"
+checksum = "ae8f206875a0603e220e7b96288112382c25c2d669d272fbb573c0faee39c7d7"
 dependencies = [
  "castep-periodic-table",
- "crystallographic-group",
+ "crystallographic-group 0.2.0",
  "nalgebra",
 ]
 
@@ -77,14 +71,25 @@ checksum = "003686f997f90473f717e340b5f14b57e113a5ea9b94f0d6f41116e6222ce3bd"
 dependencies = [
  "fraction",
  "nalgebra",
- "winnow",
+ "winnow 0.6.26",
+]
+
+[[package]]
+name = "crystallographic-group"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49dc8abde71c0f6b827259d4528a651c80551b189fd9cc2e069f37d2a92d5559"
+dependencies = [
+ "fraction",
+ "nalgebra",
+ "winnow 0.7.6",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fraction"
@@ -115,9 +120,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -125,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -137,9 +142,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
@@ -281,27 +286,27 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -354,9 +359,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe_arch"
@@ -369,18 +374,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -415,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -426,18 +431,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -446,15 +451,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -470,9 +475,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wide"
-version = "0.7.30"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e6db2670d2be78525979e9a5f9c69d296fd7d670549fe9ebf70f8708cb5019"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -480,28 +485,36 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "castep-cell-io"
-version = "0.2.12"
+version = "0.2.14"
 dependencies = [
  "castep-periodic-table",
  "chemrust-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "castep-cell-io"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 author = ["TonyWu20"]
 description = "A crate helping to parse, edit and save `castep` input file format `.cell`"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "castep-cell-io"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 author = ["TonyWu20"]
 description = "A crate helping to parse, edit and save `castep` input file format `.cell`"
@@ -14,10 +14,10 @@ keywords = ["chemistry", "castep"]
 
 [dependencies]
 castep-periodic-table = "0.5.2"
-winnow = "0.6.13"
-chemrust-core = "0.4.0"
+winnow = "0.7.6"
+chemrust-core = "0.5.0"
 nalgebra = "0.33.*"
-crystallographic-group = "0.2.0"
+crystallographic-group = "0.3.1"
 thiserror = "2.0.8"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "castep-cell-io"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 author = ["TonyWu20"]
 description = "A crate helping to parse, edit and save `castep` input file format `.cell`"

--- a/castep-param-io/Cargo.lock
+++ b/castep-param-io/Cargo.lock
@@ -27,6 +27,7 @@ version = "0.1.2"
 dependencies = [
  "castep-param-derive",
  "derive_builder",
+ "from-pest",
  "pest",
  "pest-ast",
  "pest_derive",
@@ -148,6 +149,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "from-pest"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f2dbe0e5bcfc1f8a135e14cbca3dd14e0c5696f34c2a1c7c9d729c01e9ae88"
+dependencies = [
+ "log",
+ "pest",
+ "void",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "log"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,8 +222,6 @@ dependencies = [
 [[package]]
 name = "pest-ast"
 version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1f0a53a45cfbdcd93e8982d9ead828a022762b1d890f1571f2a72e64277381"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -356,3 +372,9 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/castep-param-io/Cargo.lock
+++ b/castep-param-io/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
 [[package]]
 name = "pest-ast"
 version = "0.3.5"
+source = "git+https://github.com/TonyWu20/ast.git#26ab5192f3d2afd9bf8a868a7b5ca4def394bfe3"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -363,9 +364,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "version_check"

--- a/castep-param-io/Cargo.toml
+++ b/castep-param-io/Cargo.toml
@@ -10,7 +10,7 @@ castep-param-derive = {path = "./castep-param-derive/", version="0.1"}
 derive_builder = "0.20.2"
 from-pest = "0.3.3"
 pest = "2.7.15"
-pest-ast = {path = "./ast/derive"}
+pest-ast = {git = "https://github.com/TonyWu20/ast.git"}
 pest_derive = "2.7.15"
 serde = { version = "1.0.217", features = ["derive"] }
 thiserror = "2.0.11"

--- a/castep-param-io/Cargo.toml
+++ b/castep-param-io/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2021"
 [dependencies]
 castep-param-derive = {path = "./castep-param-derive/", version="0.1"}
 derive_builder = "0.20.2"
+from-pest = "0.3.3"
 pest = "2.7.15"
-pest-ast = "0.3.5"
+pest-ast = {path = "./ast/derive"}
 pest_derive = "2.7.15"
 serde = { version = "1.0.217", features = ["derive"] }
 thiserror = "2.0.11"

--- a/castep-param-io/castep-param-derive/Cargo.lock
+++ b/castep-param-io/castep-param-derive/Cargo.lock
@@ -3,13 +3,49 @@
 version = 4
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "castep-param-derive"
 version = "0.1.0"
 dependencies = [
  "darling",
+ "from-pest",
+ "pest_derive",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -48,16 +84,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "from-pest"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f2dbe0e5bcfc1f8a135e14cbca3dd14e0c5696f34c2a1c7c9d729c01e9ae88"
+dependencies = [
+ "log",
+ "pest",
+ "void",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "log"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "pest"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -78,6 +214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,7 +242,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/castep-param-io/castep-param-derive/Cargo.lock
+++ b/castep-param-io/castep-param-derive/Cargo.lock
@@ -3,49 +3,13 @@
 version = 4
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "castep-param-derive"
 version = "0.1.0"
 dependencies = [
  "darling",
- "from-pest",
- "pest_derive",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
 ]
 
 [[package]]
@@ -84,116 +48,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "from-pest"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f2dbe0e5bcfc1f8a135e14cbca3dd14e0c5696f34c2a1c7c9d729c01e9ae88"
-dependencies = [
- "log",
- "pest",
- "void",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "libc"
-version = "0.2.169"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "log"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "once_cell"
-version = "1.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "pest"
-version = "2.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
-dependencies = [
- "once_cell",
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -214,17 +78,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,51 +95,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/castep-param-io/castep-param-derive/Cargo.toml
+++ b/castep-param-io/castep-param-derive/Cargo.toml
@@ -11,6 +11,5 @@ proc-macro2 = "1.0.92"
 quote = "1.0.38"
 syn = { version = "2.0.95", features = ["full"] }
 
-
 [lib]
-proc-macro=true
+proc_macro = true

--- a/castep-param-io/castep-param-derive/src/enum_attributes.rs
+++ b/castep-param-io/castep-param-derive/src/enum_attributes.rs
@@ -1,0 +1,68 @@
+use darling::FromAttributes;
+use quote::quote;
+use syn::{DataEnum, Ident};
+
+#[derive(FromAttributes, Default)]
+#[darling(default, attributes(keyword_display))]
+pub struct EnumAttrs {
+    pub field: String,
+    pub display_format: Option<String>,
+}
+
+pub fn data_enum_display_impl(
+    data_enum: &DataEnum,
+    struct_ident: &Ident,
+) -> proc_macro2::TokenStream {
+    let variants = data_enum.variants.iter().map(|v| {
+        let name = &v.ident;
+        let opts = EnumAttrs::from_attributes(&v.attrs).expect("Wrong attrs");
+        let display_format = if let Some(s) = opts.display_format {
+            quote!(#s)
+        } else {
+            quote!("{}")
+        };
+        match &v.fields {
+            // Don't expect this in enum
+            syn::Fields::Named(_) => unimplemented!(),
+            syn::Fields::Unnamed(_) => quote! {
+            #struct_ident::#name(t) => write!(f, #display_format, t)},
+            syn::Fields::Unit => quote! {#struct_ident::#name => write!(f, "{:?}", self)},
+        }
+    });
+    quote! {
+        impl std::fmt::Display for #struct_ident {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    #(#variants,)*
+                }
+            }
+        }
+    }
+}
+
+pub fn data_enum_field_impl(
+    data_enum: &DataEnum,
+    struct_ident: &Ident,
+) -> proc_macro2::TokenStream {
+    let variants = data_enum.variants.iter().map(|v| {
+        let name = &v.ident;
+        let variant_expr = match v.fields {
+            // Don't expect this in enum
+            syn::Fields::Named(_) => unimplemented!(),
+            syn::Fields::Unnamed(_) => quote! {#struct_ident::#name(_)},
+            syn::Fields::Unit => quote! {#struct_ident::#name},
+        };
+        let opts = EnumAttrs::from_attributes(&v.attrs).expect("Wrong attrs");
+        let field = opts.field;
+        quote! {
+            #variant_expr => #field.to_string()
+        }
+    });
+    quote! {
+        fn field(&self) -> String {
+            match self {
+                #(#variants,)*
+            }
+        }
+    }
+}

--- a/castep-param-io/castep-param-derive/src/lib.rs
+++ b/castep-param-io/castep-param-derive/src/lib.rs
@@ -354,14 +354,14 @@ pub fn derive_consume_pairs(input: TokenStream) -> TokenStream {
     impl<'a> crate::parser::ConsumeKVPairs<'a> for #ident {
         type Item = #ident;
 
-        fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
-            let found_index = pairs
+        fn find_from_pairs(items: &'a [crate::parser::ParamItems<'a>]) -> Option<Self::Item> {
+            let found_index = items
                 .iter()
                 .position(|pair| pair.keyword().to_uppercase() == #keyword);
             match found_index {
                 Some(i) => {
-                    let pair = pairs[i];
-                    let kvpair = pair.to_string();
+                    let item = items[i];
+                    let kvpair = item.to_string();
                     let mut parse = crate::parser::ParamParser::parse(#rule, &kvpair).unwrap();
                     // let err_message = format!("Incorrect value for {}", #ident.field());
                     Some(#ident::from_pest(&mut parse).unwrap())
@@ -388,7 +388,7 @@ pub fn derive_struct_consume_pairs(input: TokenStream) -> TokenStream {
         f.ident.as_ref().map(|ident| {
             let ty = extract_type_from_option(&f.ty).expect("The type T is wrapped in Option<T>");
             quote! {
-                let #ident = #ty::find_from_pairs(pairs);
+                let #ident = #ty::find_from_pairs(items);
             }
         })
     });
@@ -396,7 +396,7 @@ pub fn derive_struct_consume_pairs(input: TokenStream) -> TokenStream {
         impl<'a> crate::parser::ConsumeKVPairs<'a> for #struct_ident {
             type Item = #struct_ident;
 
-            fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
+            fn find_from_pairs(items: &'a [crate::parser::ParamItems<'a>]) -> Option<Self::Item> {
                 #(#fields_builder)*
                 Some(Self {
                     #(#fields_idents,)*

--- a/castep-param-io/castep-param-derive/src/param_display_impl.rs
+++ b/castep-param-io/castep-param-derive/src/param_display_impl.rs
@@ -1,0 +1,15 @@
+use darling::{FromAttributes, FromDeriveInput};
+use syn::Expr;
+
+#[derive(FromAttributes, Default)]
+#[darling(default, attributes(param_display))]
+pub(crate) struct ParamFieldOpt {
+    pub use_ref: Option<bool>,
+    pub display: Option<Expr>,
+}
+
+#[derive(FromDeriveInput, Default)]
+#[darling(default, attributes(param_display))]
+pub(crate) struct ParamOpt {
+    pub use_display: Option<bool>,
+}

--- a/castep-param-io/castep-param-derive/src/strip_option.rs
+++ b/castep-param-io/castep-param-derive/src/strip_option.rs
@@ -1,0 +1,43 @@
+pub fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
+    use syn::{GenericArgument, Path, PathArguments, PathSegment};
+
+    fn extract_type_path(ty: &syn::Type) -> Option<&Path> {
+        match *ty {
+            syn::Type::Path(ref typepath) if typepath.qself.is_none() => Some(&typepath.path),
+            _ => None,
+        }
+    }
+
+    // TODO store (with lazy static) the vec of string
+    // TODO maybe optimization, reverse the order of segments
+    fn extract_option_segment(path: &Path) -> Option<&PathSegment> {
+        let idents_of_path = path
+            .segments
+            .iter()
+            .into_iter()
+            .fold(String::new(), |mut acc, v| {
+                acc.push_str(&v.ident.to_string());
+                acc.push('|');
+                acc
+            });
+        ["Option|", "std|option|Option|", "core|option|Option|"]
+            .into_iter()
+            .find(|s| &idents_of_path == *s)
+            .and_then(|_| path.segments.last())
+    }
+
+    extract_type_path(ty)
+        .and_then(|path| extract_option_segment(path))
+        .and_then(|path_seg| {
+            let type_params = &path_seg.arguments;
+            // It should have only on angle-bracketed param ("<String>"):
+            match *type_params {
+                PathArguments::AngleBracketed(ref params) => params.args.first(),
+                _ => None,
+            }
+        })
+        .and_then(|generic_arg| match *generic_arg {
+            GenericArgument::Type(ref ty) => Some(ty),
+            _ => None,
+        })
+}

--- a/castep-param-io/create_grammar.sh
+++ b/castep-param-io/create_grammar.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+printf "%s\n" "rule name:"
+input="$(</dev/stdin)"
+printf "%s\n" "To convert:"
+rule_input="$(</dev/stdin)"
+GRAMMAR="/Users/tonywu/Library/Mobile Documents/com~apple~CloudDocs/Programming/castep-cell-io/castep-param-io/src/parser/param.pest"
+{
+	printf '%s = {^"{%s}" ~ ":" ~ %ss}\n' "$input" "$input" "$input"
+	printf '%ss = {' "$input"
+	echo "$rule_input" | ./pest_enum.sh >>"$GRAMMAR"
+} >>"$GRAMMAR"
+echo "}" >>"$GRAMMAR"

--- a/castep-param-io/create_grammar.sh
+++ b/castep-param-io/create_grammar.sh
@@ -1,12 +1,11 @@
 #! /usr/bin/env bash
-printf "%s\n" "rule name:"
-input="$(</dev/stdin)"
+input=$1
 printf "%s\n" "To convert:"
-rule_input="$(</dev/stdin)"
+rule_input="$(<./paste)"
 GRAMMAR="/Users/tonywu/Library/Mobile Documents/com~apple~CloudDocs/Programming/castep-cell-io/castep-param-io/src/parser/param.pest"
 {
-	printf '%s = {^"{%s}" ~ ":" ~ %ss}\n' "$input" "$input" "$input"
+	printf '%s = {^"%s" ~ ":" ~ %ss}\n' "$input" "$input" "$input"
 	printf '%ss = {' "$input"
-	echo "$rule_input" | ./pest_enum.sh >>"$GRAMMAR"
+	echo "$rule_input" | ./pest_enum.sh
 } >>"$GRAMMAR"
 echo "}" >>"$GRAMMAR"

--- a/castep-param-io/grammar_newtype.sh
+++ b/castep-param-io/grammar_newtype.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+input=$1
+printf "%s\n" "Waiting for input from 'rule'"
+rule_input="$(<./rule)"
+printf "%s" "$rule_input"
+GRAMMAR="/Users/tonywu/Library/Mobile Documents/com~apple~CloudDocs/Programming/castep-cell-io/castep-param-io/src/parser/param.pest"
+
+printf '%s = {^"%s" ~ ":" ~ %s}\n' "$input" "$input" "$rule_input" >>"$GRAMMAR"

--- a/castep-param-io/pest_enum.sh
+++ b/castep-param-io/pest_enum.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 input=$(</dev/stdin)
-replaced=$(printf "%s" "$input" | sd '.*(".*").*' '$1 |' | gsed '$ s/|//g')
+replaced=$(printf "%s" "$input" | sd '.*(".*").*' '^$1 |' | gsed '$ s/|//g')
 printf "%s" "$replaced" | tee >(pbcopy) | bat

--- a/castep-param-io/pest_enum.sh
+++ b/castep-param-io/pest_enum.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+input=$(</dev/stdin)
+replaced=$(printf "%s" "$input" | sd '.*(".*").*' '$1 |' | gsed '$ s/|//g')
+printf "%s" "$replaced" | tee >(pbcopy) | bat

--- a/castep-param-io/pest_rule.sh
+++ b/castep-param-io/pest_rule.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+input="$(</dev/stdin)"
+rule=$(printf "%s" "$input" | gsed 's/rule(\(Rule::\(.*\)\)))/rule=\1,keyword="\U\2")/' | sd "ast" "rule")
+inner=$(printf "%s" "$input" | sd '(rule.*)\)]' 'inner($1,with(from_span)))]')
+printf "%s\n%s" "$rule" "$inner"
+printf "\n%s\n%s\n" "$rule" "$inner" | pbcopy

--- a/castep-param-io/pest_rule.sh
+++ b/castep-param-io/pest_rule.sh
@@ -1,6 +1,20 @@
 #! /bin/bash
-input="$(</dev/stdin)"
-rule=$(printf "%s" "$input" | gsed 's/rule(\(Rule::\(.*\)\)))/rule=\1,keyword="\U\2")/' | sd "ast" "rule")
-inner=$(printf "%s" "$input" | sd '(rule.*)\)]' 'inner($1,with(from_span)))]')
-printf "%s\n%s" "$rule" "$inner"
-printf "\n%s\n%s\n" "$rule" "$inner" | pbcopy
+input=$1
+file=$2
+pos=$3
+inner_type=$4
+with_funcs=$(</dev/stdin)
+dependency="use pest::{Span,Parser};\n\
+	use pest_ast::FromPest;\n\
+	use from_pest::FromPest;\n\
+	use crate::parser::Rule;"
+rule_pos=$(echo "$pos" | awk '{print $1+1}')
+inner_pos=$(echo "$rule_pos" | awk '{print $1+2}')
+ast_rule="#[pest_ast(rule(Rule::${input}))]"
+inner_rule="#[pest_ast(inner(rule(Rule::${inner_type}),${with_funcs}))]"
+rule=$(printf "%s" "$ast_rule" | gsed 's/rule(\(Rule::\(.*\)\)))/rule=\1,keyword="\U\2")/' | sd "ast" "rule")
+printf "%s\n%s" "$rule" "$inner_rule"
+gsed -i "${pos}a ${ast_rule}" "$file"
+gsed -i "${rule_pos}a ${rule}" "$file"
+gsed -i "${inner_pos}a ${inner_rule}" "$file"
+gsed -i "2a ${dependency}" "$file"

--- a/castep-param-io/span_func.sh
+++ b/castep-param-io/span_func.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+printf "%s\n" "Type:"
+type="$(</dev/stdin)"
+printf "%s\n" "To convert:"
+input="$(</dev/stdin)"
+match=$(echo "$input" | sd '\s+(.*\:\:.*) =>.*(".*").*' '$2 => Some($1),\n')
+template="
+fn from_span(span: Span<'_>) -> $type {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+     $match
+      _ => None
+  }.expect(\"Always correct\")
+}
+"
+formatted=$(printf "%s" "$template" | rustfmt)
+printf "%s" "$formatted" | bat -l rust
+printf "\n%s\n" "$formatted" | pbcopy

--- a/castep-param-io/span_func.sh
+++ b/castep-param-io/span_func.sh
@@ -1,8 +1,9 @@
 #! /bin/bash
-printf "%s\n" "Type:"
-type="$(</dev/stdin)"
+type=$1
+file=$2
+line=$3
 printf "%s\n" "To convert:"
-input="$(</dev/stdin)"
+input="$(<./paste)"
 match=$(echo "$input" | sd '\s+(.*\:\:.*) =>.*(".*").*' '$2 => Some($1),\n')
 template="
 fn from_span(span: Span<'_>) -> $type {
@@ -15,4 +16,5 @@ fn from_span(span: Span<'_>) -> $type {
 "
 formatted=$(printf "%s" "$template" | rustfmt)
 printf "%s" "$formatted" | bat -l rust
-printf "\n%s\n" "$formatted" | pbcopy
+paste=$(printf "%s\n" "$formatted" | sd '\n' '\\n')
+gsed -i -e "${line}a ${paste}" "${file}"

--- a/castep-param-io/src/lib.rs
+++ b/castep-param-io/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod param;
-// pub mod parser;
+pub mod parser;
 
 #[cfg(test)]
 mod tests {

--- a/castep-param-io/src/param/band_structure/bs_eigenvalue_tol.rs
+++ b/castep-param-io/src/param/band_structure/bs_eigenvalue_tol.rs
@@ -1,8 +1,12 @@
-use castep_param_derive::KeywordDisplayStruct;
+use crate::parser::Rule;
+use castep_param_derive::{BuildFromPairs, KeywordDisplayStruct};
 use derive_builder::Builder;
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::param::EnergyUnit;
+use crate::{param::EnergyUnit, parser::data_type::Real};
 
 /// This keyword controls the tolerance for accepting convergence of a
 /// single eigenvalue or band during a band structure calculation.
@@ -14,7 +18,17 @@ use crate::param::EnergyUnit;
 /// # Example
 /// `BS_EIGENVALUE_TOL = 1.0e-5 Ha`
 #[derive(
-    Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Builder, KeywordDisplayStruct,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    Builder,
+    KeywordDisplayStruct,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(
     field = "BS_EIGENVALUE_TOL",
@@ -22,8 +36,34 @@ use crate::param::EnergyUnit;
     default_value = 1e-6,
     display_format = "{:20.15e} {}",
 )]
+#[pest_ast(rule(Rule::bs_eigenvalue_tol))]
+#[pest_rule(rule=Rule::bs_eigenvalue_tol,keyword="BS_EIGENVALUE_TOL")]
 pub struct BSEigenvalueTol {
-    tol: f64,
+    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))]
+    pub tol: f64,
     #[keyword_display(is_option = true)]
-    unit: Option<EnergyUnit>,
+    #[pest_ast(inner(rule(Rule::bs_eigenvalue_tol_unit), with(EnergyUnit::from_span)))]
+    pub unit: Option<EnergyUnit>,
+}
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::parser::{ParamParser, Rule};
+
+    use super::BSEigenvalueTol;
+
+    #[test]
+    fn bs_eigenvalue_tol_parse() {
+        let input = "bs_eigenvalue_tol : 1e-5";
+        let mut parse = ParamParser::parse(Rule::bs_eigenvalue_tol, input).unwrap();
+        let tol = BSEigenvalueTol::from_pest(&mut parse).unwrap();
+        dbg!(tol);
+        let input_with_unit = "bs_eigenvalue_tol : 1e-5 Ha";
+        let mut parse = ParamParser::parse(Rule::bs_eigenvalue_tol, input_with_unit).unwrap();
+        let tol = BSEigenvalueTol::from_pest(&mut parse).unwrap();
+        dbg!(tol);
+    }
 }

--- a/castep-param-io/src/param/band_structure/bs_extra_bands.rs
+++ b/castep-param-io/src/param/band_structure/bs_extra_bands.rs
@@ -1,15 +1,39 @@
+use crate::parser::{
+    data_type::{PosInteger, Real},
+    ConsumeKVPairs, ParamParser, Rule,
+};
 use castep_param_derive::KeywordDisplay;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, KeywordDisplay)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, KeywordDisplay, FromPest,
+)]
 #[keyword_display(specified_fields = true)]
+#[pest_ast(rule(Rule::bs_extra_bands))]
 pub enum BSExtraBands {
     #[keyword_display(field = "BS_NEXTRA_BANDS")]
     /// This keyword controls the number of extra bands at each k-point in addition to the number of occupied bands, when performing a band structure calculation.
-    Nextra(u32),
+    Nextra(
+        #[pest_ast(inner(
+            rule(Rule::bs_nextra_bands),
+            with(BSNextraBands::from_span),
+            with(BSNextraBands::get_u64_from_nextra)
+        ))]
+        u64,
+    ),
     #[keyword_display(field = "BS_PERC_EXTRA_BANDS")]
     /// This keyword controls the number of extra bands at each k-point in addition to the number of occupied bands, when performing a band structure calculation.
-    PercExtra(f64),
+    PercExtra(
+        #[pest_ast(inner(
+            rule(Rule::bs_perc_extra_bands),
+            with(BSPercExtraBands::from_span),
+            with(BSPercExtraBands::get_f64_from_nextra)
+        ))]
+        f64,
+    ),
 }
 
 impl Default for BSExtraBands {
@@ -18,9 +42,78 @@ impl Default for BSExtraBands {
     }
 }
 
+#[derive(Debug, Clone, Copy, FromPest)]
+#[pest_ast(rule(Rule::bs_nextra_bands))]
+struct BSNextraBands<'a>(PosInteger<'a>);
+
+impl<'a> BSNextraBands<'a> {
+    fn from_span(span: Span<'a>) -> Self {
+        let input = span.as_str();
+        let mut parsed = ParamParser::parse(Rule::bs_nextra_bands, input).unwrap();
+        Self::from_pest(&mut parsed).unwrap()
+    }
+    fn get_u64_from_nextra(nextra: BSNextraBands<'_>) -> u64 {
+        nextra.0.try_into().unwrap()
+    }
+}
+
+#[derive(Debug, Clone, Copy, FromPest)]
+#[pest_ast(rule(Rule::bs_perc_extra_bands))]
+struct BSPercExtraBands<'a>(Real<'a>);
+
+impl<'a> BSPercExtraBands<'a> {
+    fn from_span(span: Span<'a>) -> Self {
+        let input = span.as_str();
+        let mut parsed = ParamParser::parse(Rule::bs_perc_extra_bands, input).unwrap();
+        Self::from_pest(&mut parsed).unwrap()
+    }
+    fn get_f64_from_nextra(perc_extra: BSPercExtraBands<'_>) -> f64 {
+        perc_extra.0.into()
+    }
+}
+
+impl<'a> ConsumeKVPairs<'a> for BSExtraBands {
+    type Item = BSExtraBands;
+
+    fn find_from_pairs(items: &'a [crate::parser::ParamItems<'a>]) -> Option<Self::Item> {
+        {
+            let nextra = items
+                .iter()
+                .position(|p| p.keyword().to_lowercase() == "bs_nextra_bands");
+            let perc_extra = items
+                .iter()
+                .position(|p| p.keyword().to_lowercase() == "bs_perc_extra_bands");
+            match (nextra, perc_extra) {
+                (None, None) => None,
+                (None, Some(i)) | (Some(i), None) => {
+                    let item = items[i];
+                    let input = item.to_string();
+                    let mut parsed =
+                        ParamParser::parse(Rule::bs_extra_bands, &input).expect("Always correct");
+                    Some(BSExtraBands::from_pest(&mut parsed).expect("Always correct"))
+                }
+                (Some(n), Some(p)) => {
+                    let to_use = if n > p { n } else { p };
+                    let item = items[to_use];
+                    let input = item.to_string();
+                    let mut parsed =
+                        ParamParser::parse(Rule::bs_extra_bands, &input).expect("Always correct");
+                    Some(BSExtraBands::from_pest(&mut parsed).expect("Always correct"))
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use crate::param::KeywordDisplay;
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::{
+        param::KeywordDisplay,
+        parser::{ConsumeKVPairs, ParamFile, ParamParser, Rule},
+    };
 
     use super::BSExtraBands;
 
@@ -30,5 +123,14 @@ mod test {
         assert_eq!(nextra.output(), "BS_NEXTRA_BANDS : 64");
         let perc_extra = BSExtraBands::PercExtra(72.0);
         assert_eq!(perc_extra.output(), "BS_PERC_EXTRA_BANDS : 72");
+        let input = perc_extra.output();
+        let mut parsed = ParamParser::parse(Rule::param_file, &input).unwrap();
+        let file = ParamFile::from_pest(&mut parsed).unwrap();
+        dbg!(&file);
+        let found = BSExtraBands::find_from_pairs(file.items());
+        dbg!(found);
+        let mut parsed = ParamParser::parse(Rule::bs_extra_bands, &input).unwrap();
+        let extra = BSExtraBands::from_pest(&mut parsed).expect("Correct");
+        dbg!(extra);
     }
 }

--- a/castep-param-io/src/param/band_structure/bs_max_cg_steps.rs
+++ b/castep-param-io/src/param/band_structure/bs_max_cg_steps.rs
@@ -1,5 +1,10 @@
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
+
+use crate::parser::{data_type::PosInteger, Rule};
 
 /// This keyword controls the maximum number of conjugate gradient steps taken
 /// for each electronic band in the electronic minimizer before resetting to the
@@ -9,10 +14,31 @@ use serde::{Deserialize, Serialize};
 /// # Example
 /// `BS_MAX_CG_STEPS : 10`
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
-#[keyword_display(field="BS_MAX_CG_STEPS", from=u32, value=u32, default_value=4)]
-pub struct BSMaxCgSteps(u32);
+#[keyword_display(field="BS_MAX_CG_STEPS", from=u64, value=u64, default_value=4)]
+#[pest_ast(rule(Rule::bs_max_cg_steps))]
+#[pest_rule(rule=Rule::bs_max_cg_steps,keyword="BS_MAX_CG_STEPS")]
+pub struct BSMaxCgSteps(
+    #[pest_ast(inner(
+        rule(Rule::pos_integer),
+        with(PosInteger::new),
+        with(u64::try_from),
+        with(Result::unwrap),
+    ))]
+    u64,
+);
 
 #[cfg(test)]
 mod test {

--- a/castep-param-io/src/param/band_structure/bs_max_iter.rs
+++ b/castep-param-io/src/param/band_structure/bs_max_iter.rs
@@ -1,5 +1,10 @@
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
+
+use crate::parser::{data_type::PosInteger, Rule};
 /// This keyword controls the maximum number of iterations to perform when
 /// calculating band structure.
 /// # Note
@@ -9,10 +14,32 @@ use serde::{Deserialize, Serialize};
 /// # Example
 /// `BS_MAX_ITER : 50`
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
-#[keyword_display(field="BS_MAX_ITER", from=u32,value=u32, default_value=60)]
-pub struct BSMaxIter(u32);
+#[keyword_display(field="BS_MAX_ITER", from=u64,value=u64, default_value=60)]
+#[pest_ast(rule(Rule::bs_max_iter))]
+#[pest_rule(rule=Rule::bs_max_iter,keyword="BS_MAX_ITER")]
+pub struct BSMaxIter(
+    #[pest_ast(inner(
+        rule(Rule::pos_integer),
+        with(PosInteger::new),
+        with(u64::try_from),
+        with(Result::unwrap)
+    ))]
+    u64,
+);
 
 #[cfg(test)]
 mod test {

--- a/castep-param-io/src/param/band_structure/bs_nbands.rs
+++ b/castep-param-io/src/param/band_structure/bs_nbands.rs
@@ -1,4 +1,8 @@
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::PosInteger, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::Nbands;
@@ -8,10 +12,10 @@ use crate::param::Nbands;
 /// k-point:
 /// 1. Directly, using BS_NBANDS.
 /// 2. Indirectly, by specifying the number of extra bands in addition to the
-/// number of occupied bands using BS_NEXTRA_BANDS.
+///    number of occupied bands using BS_NEXTRA_BANDS.
 /// 3. Indirectly, by specifying the number of extra bands in addition to
-/// the number of occupied bands as a percentage of the latter value using
-/// BS_PERC_EXTRA_BANDS.
+///    the number of occupied bands as a percentage of the latter value using
+///    BS_PERC_EXTRA_BANDS.
 /// # Note
 /// It is not possible to have both the BS_NBANDS keyword and either the
 /// BS_NEXTRA_BANDS or BS_PERC_EXTRA_BANDS keywords present in the same input file.
@@ -32,13 +36,25 @@ use crate::param::Nbands;
     Hash,
     KeywordDisplay,
     Default,
+    FromPest,
+    BuildFromPairs,
 )]
-#[keyword_display(field="BS_NBANDS", from=u32,value=u32,)]
-pub struct BSNbands(u32);
+#[keyword_display(field="BS_NBANDS", from=u64,value=u64,)]
+#[pest_ast(rule(Rule::bs_nbands))]
+#[pest_rule(rule=Rule::bs_nbands,keyword="BS_NBANDS")]
+pub struct BSNbands(
+    #[pest_ast(inner(
+        rule(Rule::pos_integer),
+        with(PosInteger::new),
+        with(u64::try_from),
+        with(Result::unwrap)
+    ))]
+    u64,
+);
 
 impl BSNbands {
     fn default_value(nbands: &Nbands) -> Self {
-        let value = (nbands.value() as f64 + 5.0 * (nbands.value() as f64).sqrt()) as u32;
+        let value = (nbands.value() as f64 + 5.0 * (nbands.value() as f64).sqrt()) as u64;
         Self(value)
     }
 }

--- a/castep-param-io/src/param/band_structure/bs_re_est_k_scrn.rs
+++ b/castep-param-io/src/param/band_structure/bs_re_est_k_scrn.rs
@@ -1,5 +1,11 @@
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
+
+use crate::parser::data_type::Logical;
+use crate::parser::Rule;
 
 /// This keyword determines whether or not to update the estimate of the
 /// Thomas-Fermi screening length in the screened exchange formalism before
@@ -23,10 +29,15 @@ use serde::{Deserialize, Serialize};
     Hash,
     KeywordDisplay,
     Default,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="BS_RE_EST_K_SCRN", from=bool, value=bool)]
-pub struct BSReEstKScrn(bool);
-
+#[pest_ast(rule(Rule::bs_re_est_k_scrn))]
+#[pest_rule(rule=Rule::bs_re_est_k_scrn,keyword="BS_RE_EST_K_SCRN")]
+pub struct BSReEstKScrn(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);
 #[cfg(test)]
 mod test {
     use crate::param::KeywordDisplay;

--- a/castep-param-io/src/param/band_structure/bs_write_eigenvalues.rs
+++ b/castep-param-io/src/param/band_structure/bs_write_eigenvalues.rs
@@ -1,4 +1,8 @@
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::Logical, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 #[derive(
@@ -13,6 +17,12 @@ use serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
     KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="BS_WRITE_EIGENVALUES", from=bool,value=bool)]
-pub struct BSWriteEigenvalues(bool);
+#[pest_ast(rule(Rule::bs_write_eigenvalues))]
+#[pest_rule(rule=Rule::bs_write_eigenvalues,keyword="BS_WRITE_EIGENVALUES")]
+pub struct BSWriteEigenvalues(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);

--- a/castep-param-io/src/param/band_structure/bs_xc_functional.rs
+++ b/castep-param-io/src/param/band_structure/bs_xc_functional.rs
@@ -1,12 +1,28 @@
 use std::fmt::Display;
 
-use castep_param_derive::KeywordDisplay;
+use crate::parser::Rule;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::XCFunctional;
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(direct_display = false, field = "BS_XC_FUNCTIONAL")]
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
@@ -20,7 +36,10 @@ use crate::param::XCFunctional;
 /// The default value is derived from the value for XC_FUNCTIONAL.
 /// # Example
 /// `BS_XC_FUNCTIONAL : PW91`
+#[pest_ast(rule(Rule::bs_xc_functional))]
+#[pest_rule(rule=Rule::bs_xc_functional,keyword="BS_XC_FUNCTIONAL")]
 pub enum BSXcFunctional {
+    #[pest_ast(inner(rule(Rule::bs_xc_functionals), with(from_span)))]
     LDA,
     PW91,
     PBE,
@@ -38,12 +57,47 @@ pub enum BSXcFunctional {
     RSCAN,
 }
 
+fn from_span(span: Span<'_>) -> BSXcFunctional {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "shf-lda" => Some(BSXcFunctional::SHF_LDA),
+        "hf-lda" => Some(BSXcFunctional::HF_LDA),
+        "lda" => Some(BSXcFunctional::LDA),
+        "pw91" => Some(BSXcFunctional::PW91),
+        "pbe" => Some(BSXcFunctional::PBE),
+        "rpbe" => Some(BSXcFunctional::RPBE),
+        "wc" => Some(BSXcFunctional::WC),
+        "pbesol" => Some(BSXcFunctional::PBESOL),
+        "hf" => Some(BSXcFunctional::HF),
+        "shf" => Some(BSXcFunctional::SHF),
+        "pbe0" => Some(BSXcFunctional::PBE0),
+        "b3lyp" => Some(BSXcFunctional::B3LYP),
+        "hse03" => Some(BSXcFunctional::HSE03),
+        "hse06" => Some(BSXcFunctional::HSE06),
+        "rscan" => Some(BSXcFunctional::RSCAN),
+        _ => None,
+    }
+    .expect("Always correct")
+}
+
 impl Display for BSXcFunctional {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             BSXcFunctional::SHF_LDA => f.write_str("SHF-LDA"),
             BSXcFunctional::HF_LDA => f.write_str("HF-LDA"),
-            _ => write!(f, "{:?}", self),
+            BSXcFunctional::LDA => f.write_str("lda"),
+            BSXcFunctional::PW91 => f.write_str("pw91"),
+            BSXcFunctional::PBE => f.write_str("pbe"),
+            BSXcFunctional::RPBE => f.write_str("rpbe"),
+            BSXcFunctional::WC => f.write_str("wc"),
+            BSXcFunctional::PBESOL => f.write_str("pbesol"),
+            BSXcFunctional::HF => f.write_str("hf"),
+            BSXcFunctional::SHF => f.write_str("shf"),
+            BSXcFunctional::PBE0 => f.write_str("pbe0"),
+            BSXcFunctional::B3LYP => f.write_str("b3lyp"),
+            BSXcFunctional::HSE03 => f.write_str("hse03"),
+            BSXcFunctional::HSE06 => f.write_str("hse06"),
+            BSXcFunctional::RSCAN => f.write_str("rscan"),
         }
     }
 }

--- a/castep-param-io/src/param/band_structure/mod.rs
+++ b/castep-param-io/src/param/band_structure/mod.rs
@@ -1,5 +1,5 @@
 use crate::param::KeywordDisplay;
-use castep_param_derive::ParamDisplay;
+use castep_param_derive::{ParamDisplay, StructBuildFromPairs};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
@@ -32,6 +32,7 @@ pub use bs_xc_functional::BSXcFunctional;
     Default,
     Serialize,
     Deserialize,
+    StructBuildFromPairs,
 )]
 #[builder(setter(into, strip_option), default)]
 pub struct BandStructure {

--- a/castep-param-io/src/param/basis_set/basis_precision.rs
+++ b/castep-param-io/src/param/basis_set/basis_precision.rs
@@ -1,7 +1,9 @@
-
-use castep_param_derive::KeywordDisplay;
+use crate::parser::Rule;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
-
 
 /// This keywords specifies the precision of the basis set by choosing the level of convergence of atomic energies with respect to the plane wave cutoff energy for the pseudopotentials used in the calculation.
 /// Available options are:
@@ -10,6 +12,7 @@ use serde::{Deserialize, Serialize};
 /// - FINE - convergence of about 0.1 eV/atom
 /// - PRECISE - 1.2 × FINE cutoff energy
 /// - EXTREME - 1.6 × FINE cutoff energy, convergence of about 0.01 eV/atom
+///
 /// If the `BASIS_PRECISION` is defined, the `CUT_OFF_ENERGY` will be equal to the highest of the cutoff energies associated with the chosen level of accuracy, for the pseudopotentials used in the calculation.
 /// # Note
 /// It is not possible to specify both the `BASIS_PRECISION` and the `CUT_OFF_ENERGY` in a single file.
@@ -26,13 +29,31 @@ use serde::{Deserialize, Serialize};
     PartialOrd,
     Ord,
     KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field = "BASIS_PRECISION")]
+#[pest_ast(rule(Rule::basis_precision))]
+#[pest_rule(rule=Rule::basis_precision,keyword="BASIS_PRECISION")]
 pub enum BasisPrecision {
+    #[pest_ast(inner(rule(Rule::basis_precisions), with(from_span)))]
     Coarse,
     Medium,
     #[default]
     Fine,
     Precise,
     Extreme,
+}
+
+fn from_span(span: Span<'_>) -> BasisPrecision {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "coarse" => Some(BasisPrecision::Coarse),
+        "medium" => Some(BasisPrecision::Medium),
+        "fine" => Some(BasisPrecision::Fine),
+        "precise" => Some(BasisPrecision::Precise),
+        "extreme" => Some(BasisPrecision::Extreme),
+        _ => None,
+    }
+    .expect("Always correct")
 }

--- a/castep-param-io/src/param/basis_set/cut_off_energy.rs
+++ b/castep-param-io/src/param/basis_set/cut_off_energy.rs
@@ -1,7 +1,9 @@
-
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::Real, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
-
 
 /// This keyword specifies the cutoff energy for the plane wave basis sets that will be used in the calculation.
 /// If the BASIS_PRECISION is defined, the cutoff energy will be equal to the highest of the cutoff energies associated with the chosen level of accuracy, for the pseudopotentials used in the calculation.
@@ -9,7 +11,21 @@ use serde::{Deserialize, Serialize};
 /// # Note
 /// It is not possible to specify both the BASIS_PRECISION and the CUT_OFF_ENERGY in a single file.
 #[derive(
-    Debug, Clone, Copy, Deserialize, Serialize, PartialEq, PartialOrd, Default, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    Deserialize,
+    Serialize,
+    PartialEq,
+    PartialOrd,
+    Default,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="CUT_OFF_ENERGY", from=f64, value=f64, display_format="{:20.15}")]
-pub struct CutoffEnergy(f64);
+#[pest_ast(rule(Rule::cut_off_energy))]
+#[pest_rule(rule=Rule::cut_off_energy,keyword="CUT_OFF_ENERGY")]
+pub struct CutoffEnergy(
+    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64,
+);

--- a/castep-param-io/src/param/basis_set/fine_gmax.rs
+++ b/castep-param-io/src/param/basis_set/fine_gmax.rs
@@ -1,5 +1,9 @@
-use castep_param_derive::KeywordDisplayStruct;
+use crate::parser::{data_type::Real, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplayStruct};
 use derive_builder::Builder;
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::InvLengthUnit;
@@ -10,12 +14,48 @@ use crate::param::InvLengthUnit;
 /// # Example
 /// FINE_GMAX : 20 1/angt up such that all g-vectors with |g| less than or equal to FINE_GMAX are included.
 #[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, Builder, KeywordDisplayStruct,
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    PartialOrd,
+    Builder,
+    KeywordDisplayStruct,
+    FromPest,
+    BuildFromPairs,
 )]
 #[builder(setter(into), default)]
 #[keyword_display(field = "FINE_GMAX", display_format="{:20.15} {}", default_value=-1.0, from=f64)]
+#[pest_ast(rule(Rule::fine_gmax))]
+#[pest_rule(rule=Rule::fine_gmax,keyword="FINE_GMAX")]
 pub struct FineGMax {
+    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))]
     pub max: f64,
     #[keyword_display(is_option = true)]
+    #[pest_ast(inner(rule(Rule::fine_gmax_unit), with(InvLengthUnit::from_span)))]
     pub unit: Option<InvLengthUnit>,
+}
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::parser::{ConsumeKVPairs, ParamFile, ParamParser, Rule};
+
+    use super::FineGMax;
+
+    #[test]
+    fn fine_gmax_parse() {
+        let input = ["fine_gmax : 2.0000", "fine_gmax : 2.0000 1/nm"];
+        input.iter().for_each(|&input| {
+            let mut parse = ParamParser::parse(Rule::param_file, input).unwrap();
+            let file = ParamFile::from_pest(&mut parse).unwrap();
+            dbg!(&file);
+            let gmax = FineGMax::find_from_pairs(file.items());
+            dbg!(gmax);
+        });
+    }
 }

--- a/castep-param-io/src/param/basis_set/fine_grid_scale.rs
+++ b/castep-param-io/src/param/basis_set/fine_grid_scale.rs
@@ -1,4 +1,8 @@
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::Real, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 /// This keyword determines the maximum size of the g-vectors included in the fine grid relative to the standard grid.
@@ -6,9 +10,24 @@ use serde::{Deserialize, Serialize};
 /// 1  - this results in the fine and standard grids being identical
 /// # Example
 /// `FINE_GRID_SCALE : 2.0`
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, KeywordDisplay)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+)]
 #[keyword_display(display_format="{:20.15}", from=f64,value=f64, field="FINE_GRID_SCALE", default_value=1.0)]
-pub struct FineGridScale(f64);
+#[pest_ast(rule(Rule::fine_grid_scale))]
+#[pest_rule(rule=Rule::fine_grid_scale,keyword="FINE_GRID_SCALE")]
+pub struct FineGridScale(
+    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64,
+);
 
 #[cfg(test)]
 mod test {

--- a/castep-param-io/src/param/basis_set/finite_basis_corr.rs
+++ b/castep-param-io/src/param/basis_set/finite_basis_corr.rs
@@ -1,6 +1,10 @@
 use std::fmt::Display;
 
-use castep_param_derive::KeywordDisplay;
+use crate::parser::Rule;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 /// This keyword determines whether or not to apply a finite basis set correction to energy and stress when cell parameters change.
@@ -24,9 +28,14 @@ use serde::{Deserialize, Serialize};
     Deserialize,
     Default,
     KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(direct_display = false, field = "FINITE_BASIS_CORR")]
+#[pest_ast(rule(Rule::finite_basis_corr))]
+#[pest_rule(rule=Rule::finite_basis_corr,keyword="FINITE_BASIS_CORR")]
 pub enum FiniteBasisCorr {
+    #[pest_ast(inner(rule(Rule::finite_basis_corrs), with(from_span)))]
     /// 0
     NoCorrection,
     /// 1
@@ -34,6 +43,17 @@ pub enum FiniteBasisCorr {
     #[default]
     /// 2
     Auto,
+}
+
+fn from_span(span: Span<'_>) -> FiniteBasisCorr {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "0" => Some(FiniteBasisCorr::NoCorrection),
+        "1" => Some(FiniteBasisCorr::Manual),
+        "2" => Some(FiniteBasisCorr::Auto),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for FiniteBasisCorr {

--- a/castep-param-io/src/param/basis_set/finite_basis_npoints.rs
+++ b/castep-param-io/src/param/basis_set/finite_basis_npoints.rs
@@ -1,4 +1,8 @@
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::PosInteger, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 /// This keyword controls the number of points used to estimate the BASIS_DE_DLOGE in automatic calculation of the finite basis set correction. Points are chosen such that the CUT_OFF_ENERGY corresponds to the highest energy in the set of FINITE_BASIS_NPOINTS cutoff energies.
@@ -9,7 +13,29 @@ use serde::{Deserialize, Serialize};
 /// # Example
 /// `FINITE_BASIS_NPOINTS : 5`
 #[derive(
-    Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
-#[keyword_display(field="FINITE_BASIS_NPOINTS", from=u32, value=u32, default_value=3)]
-pub struct FiniteBasisNPoints(u32);
+#[keyword_display(field="FINITE_BASIS_NPOINTS", from=u64, value=u64, default_value=3)]
+#[pest_ast(rule(Rule::finite_basis_npoints))]
+#[pest_rule(rule=Rule::finite_basis_npoints,keyword="FINITE_BASIS_NPOINTS")]
+pub struct FiniteBasisNPoints(
+    #[pest_ast(inner(
+        rule(Rule::pos_integer),
+        with(PosInteger::new),
+        with(u64::try_from),
+        with(Result::unwrap),
+    ))]
+    u64,
+);

--- a/castep-param-io/src/param/basis_set/finite_basis_spacing.rs
+++ b/castep-param-io/src/param/basis_set/finite_basis_spacing.rs
@@ -1,5 +1,9 @@
-use castep_param_derive::KeywordDisplayStruct;
+use crate::parser::{data_type::Real, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplayStruct};
 use derive_builder::Builder;
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::EnergyUnit;
@@ -10,12 +14,26 @@ use crate::param::EnergyUnit;
 /// # Note
 /// This value is only used if FINITE_BASIS_CORR : 2.
 #[derive(
-    Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Builder, KeywordDisplayStruct,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    Builder,
+    KeywordDisplayStruct,
+    FromPest,
+    BuildFromPairs,
 )]
 #[builder(setter(into), default)]
 #[keyword_display(field = "FINITE_BASIS_SPACING", from=f64, default_value=5.0, display_format="{:20.15} {}")]
+#[pest_ast(rule(Rule::finite_basis_spacing))]
+#[pest_rule(rule=Rule::finite_basis_spacing,keyword="FINITE_BASIS_SPACING")]
 pub struct FiniteBasisSpacing {
+    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))]
     spacing: f64,
     #[keyword_display(is_option = true)]
+    #[pest_ast(inner(rule(Rule::finite_basis_spacing_units), with(EnergyUnit::from_span)))]
     unit: Option<EnergyUnit>,
 }

--- a/castep-param-io/src/param/basis_set/fixed_npw.rs
+++ b/castep-param-io/src/param/basis_set/fixed_npw.rs
@@ -1,7 +1,9 @@
-
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::Logical, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
-
 
 /// This keyword determines whether a fixed number of plane waves (fixed size
 /// basis : TRUE) or a fixed plane wave cutoff energy
@@ -29,6 +31,12 @@ use serde::{Deserialize, Serialize};
     Hash,
     Default,
     KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="FIXED_NPW", from=bool,value=bool)]
-pub struct FixedNPW(bool);
+#[pest_ast(rule(Rule::fixed_npw))]
+#[pest_rule(rule=Rule::fixed_npw,keyword="FIXED_NPW")]
+pub struct FixedNPW(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);

--- a/castep-param-io/src/param/basis_set/grid_scale.rs
+++ b/castep-param-io/src/param/basis_set/grid_scale.rs
@@ -1,4 +1,8 @@
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::Real, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 /// This keyword determines the size of the standard grid, relative to the diameter of the cutoff sphere.
@@ -6,11 +10,26 @@ use serde::{Deserialize, Serialize};
 /// `1.75`
 /// # Example
 /// `GRID_SCALE : 2.0`
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, KeywordDisplay)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+)]
 #[keyword_display(field="GRID_SCALE",
     from=f64,
     value=f64,
     display_format="{:20.15}",
     default_value=1.75
 )]
-pub struct GridScale(f64);
+#[pest_ast(rule(Rule::grid_scale))]
+#[pest_rule(rule=Rule::grid_scale,keyword="GRID_SCALE")]
+pub struct GridScale(
+    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64,
+);

--- a/castep-param-io/src/param/basis_set/mod.rs
+++ b/castep-param-io/src/param/basis_set/mod.rs
@@ -1,4 +1,4 @@
-use castep_param_derive::ParamDisplay;
+use castep_param_derive::{ParamDisplay, StructBuildFromPairs};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
@@ -37,6 +37,7 @@ use super::KeywordDisplay;
     ParamDisplay,
     PartialEq,
     PartialOrd,
+    StructBuildFromPairs,
 )]
 #[builder(
     setter(into, strip_option),

--- a/castep-param-io/src/param/electronic/bands_option/extra_bands.rs
+++ b/castep-param-io/src/param/electronic/bands_option/extra_bands.rs
@@ -1,7 +1,17 @@
 use castep_param_derive::KeywordDisplay;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, KeywordDisplay)]
+use crate::parser::{
+    data_type::{PosInteger, Real},
+    ConsumeKVPairs, ParamParser, Rule,
+};
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, KeywordDisplay, FromPest,
+)]
 /// This keyword controls the percentage of extra bands in addition to the number
 /// of occupied bands. These extra bands are necessary for metals or finite
 /// temperature insulators.
@@ -9,9 +19,83 @@ use serde::{Deserialize, Serialize};
 /// It is not possible to have both the NBANDS keyword and either the NEXTRA_BANDS
 /// or PERC_EXTRA_BANDS keywords present in the same input file.
 #[keyword_display(specified_fields = true)]
+#[pest_ast(rule(Rule::extra_bands))]
 pub enum ExtraBands {
     #[keyword_display(field = "NEXTRA_BANDS")]
-    NextraBands(u32),
+    NextraBands(
+        #[pest_ast(inner(
+            rule(Rule::nextra_bands),
+            with(NextraBands::from_span),
+            with(NextraBands::get_u64_from_nextra)
+        ))]
+        u64,
+    ),
     #[keyword_display(field = "PERC_EXTRA_BANDS")]
-    PercExtraBands(f64),
+    PercExtraBands(
+        #[pest_ast(inner(
+            rule(Rule::perc_extra_bands),
+            with(PercExtraBands::from_span),
+            with(PercExtraBands::get_f64_from_nextra)
+        ))]
+        f64,
+    ),
+}
+
+#[derive(Debug, Clone, Copy, FromPest)]
+#[pest_ast(rule(Rule::nextra_bands))]
+struct NextraBands<'a>(PosInteger<'a>);
+
+impl<'a> NextraBands<'a> {
+    fn from_span(span: Span<'a>) -> Self {
+        let input = span.as_str();
+        let mut parsed = ParamParser::parse(Rule::nextra_bands, input).unwrap();
+        Self::from_pest(&mut parsed).unwrap()
+    }
+    fn get_u64_from_nextra(nextra: NextraBands<'_>) -> u64 {
+        nextra.0.try_into().unwrap()
+    }
+}
+
+#[derive(Debug, Clone, Copy, FromPest)]
+#[pest_ast(rule(Rule::perc_extra_bands))]
+struct PercExtraBands<'a>(Real<'a>);
+
+impl<'a> PercExtraBands<'a> {
+    fn from_span(span: Span<'a>) -> Self {
+        let input = span.as_str();
+        let mut parsed = ParamParser::parse(Rule::perc_extra_bands, input).unwrap();
+        Self::from_pest(&mut parsed).unwrap()
+    }
+    fn get_f64_from_nextra(perc_extra: PercExtraBands<'_>) -> f64 {
+        perc_extra.0.into()
+    }
+}
+
+impl<'a> ConsumeKVPairs<'a> for ExtraBands {
+    type Item = ExtraBands;
+
+    fn find_from_pairs(items: &'a [crate::parser::ParamItems<'a>]) -> Option<Self::Item> {
+        {
+            let nextra = items
+                .iter()
+                .position(|p| p.keyword().to_lowercase() == "nextra_bands");
+            let perc_extra = items
+                .iter()
+                .position(|p| p.keyword().to_lowercase() == "perc_extra_bands");
+            let item = match (nextra, perc_extra) {
+                (None, None) => None,
+                (None, Some(i)) | (Some(i), None) => Some(items[i]),
+                (Some(n), Some(p)) => {
+                    let to_use = if n > p { n } else { p };
+                    Some(items[to_use])
+                }
+            };
+            item.map(|i| {
+                let input = i.to_string();
+                let mut parsed =
+                    ParamParser::parse(Rule::extra_bands, &input).expect("Always correct");
+                ExtraBands::from_pest(&mut parsed).expect("Always correct")
+            })
+        }
+    }
 }

--- a/castep-param-io/src/param/electronic/bands_option/mod.rs
+++ b/castep-param-io/src/param/electronic/bands_option/mod.rs
@@ -1,12 +1,14 @@
-use castep_param_derive::ParamDisplay;
+use castep_param_derive::{ParamDisplay, StructBuildFromPairs};
 use derive_builder::Builder;
-pub use extra_bands::ExtraBands;
-pub use nbands::Nbands;
 use serde::{Deserialize, Serialize};
 
 use crate::param::KeywordDisplay;
 
 mod extra_bands;
+mod nbands;
+
+pub use extra_bands::ExtraBands;
+pub use nbands::Nbands;
 /// This keyword determines the maximum number of bands at any k-point and spin.
 /// There are three ways in which you can specify the maximum number of bands at any k-point and spin:
 /// Directly, using `NBANDS`.
@@ -25,83 +27,10 @@ mod extra_bands;
     Builder,
     Default,
     ParamDisplay,
+    StructBuildFromPairs,
 )]
 #[builder(setter(into, strip_option), default)]
 pub struct BandsOption {
     nbands: Option<Nbands>,
     extra_bands: Option<ExtraBands>,
-}
-
-mod nbands {
-
-    use castep_param_derive::KeywordDisplay;
-    use serde::{Deserialize, Serialize};
-
-    use crate::param::{ElectronicParam, SpinPolarised};
-
-    use super::extra_bands::ExtraBands;
-
-    #[derive(
-        Debug,
-        Clone,
-        Copy,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Hash,
-        Serialize,
-        Deserialize,
-        KeywordDisplay,
-    )]
-    #[keyword_display(field = "NBANDS", from = u32, value=u32)]
-    pub struct Nbands(u32);
-
-    impl Nbands {
-        /// If NEXTRA_BANDS is specified and SPIN_POLARIZED : FALSE:
-        /// NBANDS : (NELECTRONS/2) + NEXTRA_BANDS
-        /// Or, if SPIN_POLARIZED : TRUE:
-        ///     NBANDS : max(NUP, NDOWN) + NEXTRA_BANDS.
-        /// If PERC_EXTRA_BANDS is specified and SPIN_POLARIZED : FALSE:
-        ///     NBANDS : (NELECTRONS/2) × [ 1 + (PERC_EXTRA_BANDS/100)]
-        /// Or, if SPIN_POLARIZED : TRUE:
-        ///     NBANDS : max(NUP, NDOWN) × [ 1 + (PERC_EXTRA_BANDS/100)]
-        /// If NBANDS, NEXTRA_BANDS and PERC_EXTRA_BANDS are not specified and FIX_OCCUPANCY : TRUE, then, if SPIN_POLARIZED : FALSE:
-        ///     NBANDS : NELECTRONS/2.
-        /// Or, if SPIN_POLARIZED : TRUE:
-        ///     NBANDS : max(NUP, NDOWN)
-        /// If FIX_OCCUPANCY : FALSE, these default values of NBANDS will be multiplied by 1.2.
-        pub fn default_value(
-            electronic_param: ElectronicParam,
-            spin_polarised: SpinPolarised,
-            extra_bands: Option<ExtraBands>,
-            // fix_occupancy: FixOccupancy,
-        ) -> Self {
-            if let (Some(ExtraBands::NextraBands(nextra)), SpinPolarised::False) =
-                (extra_bands, spin_polarised)
-            {
-                let nelectrons = electronic_param
-                    .nelectrons
-                    .expect("Number of electrons of the system is not determined!");
-                return Self(nelectrons.value() as u32 / 2 + nextra);
-            }
-            if let (Some(ExtraBands::NextraBands(nextra)), SpinPolarised::True) =
-                (extra_bands, spin_polarised)
-            {
-                let nup = electronic_param
-                    .nup
-                    .expect("NUP of the system is not determined!");
-                let ndown = electronic_param
-                    .ndown
-                    .expect("NDOWN of the system is not determined!");
-                let max = if nup.value() > ndown.value() {
-                    nup.value()
-                } else {
-                    ndown.value()
-                };
-                return Self(max as u32 + nextra);
-            }
-            todo!()
-        }
-    }
 }

--- a/castep-param-io/src/param/electronic/bands_option/nbands.rs
+++ b/castep-param-io/src/param/electronic/bands_option/nbands.rs
@@ -1,0 +1,86 @@
+use crate::parser::{data_type::PosInteger, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
+use serde::{Deserialize, Serialize};
+
+use crate::param::{ElectronicParam, SpinPolarised};
+
+use super::extra_bands::ExtraBands;
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+)]
+#[keyword_display(field = "NBANDS", from = u64, value=u64)]
+#[pest_ast(rule(Rule::nbands))]
+#[pest_rule(rule=Rule::nbands,keyword="NBANDS")]
+pub struct Nbands(
+    #[pest_ast(inner(
+        rule(Rule::pos_integer),
+        with(PosInteger::new),
+        with(u64::try_from),
+        with(Result::unwrap)
+    ))]
+    u64,
+);
+
+impl Nbands {
+    /// If NEXTRA_BANDS is specified and SPIN_POLARIZED : FALSE:
+    /// NBANDS : (NELECTRONS/2) + NEXTRA_BANDS
+    /// Or, if SPIN_POLARIZED : TRUE:
+    ///     NBANDS : max(NUP, NDOWN) + NEXTRA_BANDS.
+    /// If PERC_EXTRA_BANDS is specified and SPIN_POLARIZED : FALSE:
+    ///     NBANDS : (NELECTRONS/2) × [ 1 + (PERC_EXTRA_BANDS/100)]
+    /// Or, if SPIN_POLARIZED : TRUE:
+    ///     NBANDS : max(NUP, NDOWN) × [ 1 + (PERC_EXTRA_BANDS/100)]
+    /// If NBANDS, NEXTRA_BANDS and PERC_EXTRA_BANDS are not specified and FIX_OCCUPANCY : TRUE, then, if SPIN_POLARIZED : FALSE:
+    ///     NBANDS : NELECTRONS/2.
+    /// Or, if SPIN_POLARIZED : TRUE:
+    ///     NBANDS : max(NUP, NDOWN)
+    /// If FIX_OCCUPANCY : FALSE, these default values of NBANDS will be multiplied by 1.2.
+    pub fn default_value(
+        electronic_param: ElectronicParam,
+        spin_polarised: SpinPolarised,
+        extra_bands: Option<ExtraBands>,
+        // fix_occupancy: FixOccupancy,
+    ) -> Self {
+        if let (Some(ExtraBands::NextraBands(nextra)), SpinPolarised::False) =
+            (extra_bands, spin_polarised)
+        {
+            let nelectrons = electronic_param
+                .nelectrons
+                .expect("Number of electrons of the system is not determined!");
+            return Self(nelectrons.value() as u64 / 2 + nextra);
+        }
+        if let (Some(ExtraBands::NextraBands(nextra)), SpinPolarised::True) =
+            (extra_bands, spin_polarised)
+        {
+            let nup = electronic_param
+                .nup
+                .expect("NUP of the system is not determined!");
+            let ndown = electronic_param
+                .ndown
+                .expect("NDOWN of the system is not determined!");
+            let max = if nup.value() > ndown.value() {
+                nup.value()
+            } else {
+                ndown.value()
+            };
+            return Self(max as u64 + nextra);
+        }
+        todo!()
+    }
+}

--- a/castep-param-io/src/param/electronic/charge.rs
+++ b/castep-param-io/src/param/electronic/charge.rs
@@ -1,7 +1,9 @@
-
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::Real, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
-
 
 /// Description
 /// This keyword specifies the total charge of the system. It can be used instead of `NELECTRONS`.
@@ -10,6 +12,19 @@ use serde::{Deserialize, Serialize};
 /// 0
 /// Example
 /// CHARGE : 3
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, KeywordDisplay)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    PartialOrd,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+)]
+#[pest_ast(rule(Rule::charge))]
+#[pest_rule(rule=Rule::charge,keyword="CHARGE")]
 #[keyword_display(field="CHARGE", from=f64, value=f64)]
-pub struct Charge(f64);
+pub struct Charge(#[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64);

--- a/castep-param-io/src/param/electronic/mod.rs
+++ b/castep-param-io/src/param/electronic/mod.rs
@@ -59,7 +59,6 @@ mod test {
     #[test]
     fn electronic_param() {
         let elec_param = ElectronicParamBuilder::default()
-            .spin_polarised(true)
             .spin(2.0)
             .bands_option(
                 BandsOptionBuilder::default()

--- a/castep-param-io/src/param/electronic/mod.rs
+++ b/castep-param-io/src/param/electronic/mod.rs
@@ -1,4 +1,4 @@
-use castep_param_derive::ParamDisplay;
+use castep_param_derive::{ParamDisplay, StructBuildFromPairs};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +25,7 @@ mod spin;
     ParamDisplay,
     PartialEq,
     PartialOrd,
+    StructBuildFromPairs,
 )]
 #[non_exhaustive]
 #[builder(setter(into, strip_option), default)]

--- a/castep-param-io/src/param/electronic/nelectrons/mod.rs
+++ b/castep-param-io/src/param/electronic/nelectrons/mod.rs
@@ -1,37 +1,31 @@
-
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::Real, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+mod ndown;
+mod nup;
 
 pub use ndown::NDown;
 pub use nup::NUp;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, KeywordDisplay)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    PartialOrd,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+)]
 #[keyword_display(from=f64, value=f64, field="NELECTRONS")]
-pub struct NElectrons(f64);
-
-mod nup {
-    
-
-    use castep_param_derive::KeywordDisplay;
-    use serde::{Deserialize, Serialize};
-
-    
-
-    #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, KeywordDisplay)]
-    #[keyword_display(field="NUP", from=f64, value=f64)]
-    pub struct NUp(f64);
-}
-
-mod ndown {
-    
-
-    use castep_param_derive::KeywordDisplay;
-    use serde::{Deserialize, Serialize};
-
-    
-
-    #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, KeywordDisplay)]
-    #[keyword_display(field="NDOWN", from=f64, value=f64)]
-    pub struct NDown(f64);
-}
+#[pest_ast(rule(Rule::nelectrons))]
+#[pest_rule(rule=Rule::nelectrons,keyword="NELECTRONS")]
+pub struct NElectrons(
+    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64,
+);

--- a/castep-param-io/src/param/electronic/nelectrons/ndown.rs
+++ b/castep-param-io/src/param/electronic/nelectrons/ndown.rs
@@ -13,14 +13,11 @@ use serde::{Deserialize, Serialize};
     Deserialize,
     PartialEq,
     PartialOrd,
-    Default,
     KeywordDisplay,
     FromPest,
     BuildFromPairs,
 )]
-#[keyword_display(from=f64, value=f64, field="BASIS_DE_DLOGE")]
-#[pest_ast(rule(Rule::basis_de_dloge))]
-#[pest_rule(rule=Rule::basis_de_dloge,keyword="BASIS_DE_DLOGE")]
-pub struct BasisDeDloge(
-    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64,
-);
+#[keyword_display(field="NDOWN", from=f64, value=f64)]
+#[pest_ast(rule(Rule::ndown))]
+#[pest_rule(rule=Rule::ndown,keyword="NDOWN")]
+pub struct NDown(#[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64);

--- a/castep-param-io/src/param/electronic/nelectrons/nup.rs
+++ b/castep-param-io/src/param/electronic/nelectrons/nup.rs
@@ -13,14 +13,11 @@ use serde::{Deserialize, Serialize};
     Deserialize,
     PartialEq,
     PartialOrd,
-    Default,
     KeywordDisplay,
     FromPest,
     BuildFromPairs,
 )]
-#[keyword_display(from=f64, value=f64, field="BASIS_DE_DLOGE")]
-#[pest_ast(rule(Rule::basis_de_dloge))]
-#[pest_rule(rule=Rule::basis_de_dloge,keyword="BASIS_DE_DLOGE")]
-pub struct BasisDeDloge(
-    #[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64,
-);
+#[keyword_display(field="NUP", from=f64, value=f64)]
+#[pest_ast(rule(Rule::nup))]
+#[pest_rule(rule=Rule::nup,keyword="NUP")]
+pub struct NUp(#[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64);

--- a/castep-param-io/src/param/electronic/spin.rs
+++ b/castep-param-io/src/param/electronic/spin.rs
@@ -1,17 +1,32 @@
-
-use castep_param_derive::KeywordDisplay;
+use crate::parser::{data_type::Real, Rule};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Default, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    Default,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field = "SPIN", from=f64, value=f64)]
+#[pest_ast(rule(Rule::spin))]
+#[pest_rule(rule=Rule::spin,keyword="SPIN")]
 /// This keyword determines the initial value for the number of unpaired electrons in a spin-polarized calculation. This value may be optimized during the CASTEP calculation depending on the values of SPIN_FIX and FIX_OCCUPANCY.
 /// The SPIN keyword cannot be used in conjunction with either of NUP or NDOWN keywords.
 /// # Default
 /// 0 when the total number of electrons in the system is even.
 /// 1 when the total number of electrons in the system is odd.
-pub struct Spin(f64);
+pub struct Spin(#[pest_ast(inner(rule(Rule::real), with(Real::from_span), with(f64::from)))] f64);
 
 #[cfg(test)]
 mod test {

--- a/castep-param-io/src/param/general/backup_setting.rs
+++ b/castep-param-io/src/param/general/backup_setting.rs
@@ -57,10 +57,10 @@ impl<'a> ConsumeKVPairs<'a> for BackUpSetting {
     fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
         let num_backup_iter_id = pairs
             .iter()
-            .position(|p| p.keyword().as_str().to_lowercase() == "num_backup_iter");
+            .position(|p| p.keyword().to_lowercase() == "num_backup_iter");
         let backup_interval_id = pairs
             .iter()
-            .position(|p| p.keyword().as_str().to_lowercase() == "backup_interval");
+            .position(|p| p.keyword().to_lowercase() == "backup_interval");
         match (num_backup_iter_id, backup_interval_id) {
             (None, None) => None,
             (None, Some(n)) | (Some(n), None) => {

--- a/castep-param-io/src/param/general/backup_setting.rs
+++ b/castep-param-io/src/param/general/backup_setting.rs
@@ -1,25 +1,126 @@
+use std::str::FromStr;
+
 use castep_param_derive::KeywordDisplay;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::{ConsumeKVPairs, ParamParser, Rule};
+
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    FromPest,
 )]
 #[keyword_display(specified_fields = true)]
+#[pest_ast(rule(Rule::backup_setting))]
 pub enum BackUpSetting {
+    // This keyword specifies the number of geometry optimization or molecular
+    // dynamics iterations between updates of the backup restart files.
+    #[keyword_display(field = "NUM_BACKUP_ITER")]
+    NumBackupIter(
+        #[pest_ast(inner(
+            rule(Rule::num_backup_iter),
+            with(span_into_num_backup_iter),
+            with(Result::unwrap),
+        ))]
+        u64,
+    ),
     /// This keyword specifies the interval, in seconds, between updates of the
     /// backup restart files. This keyword is applicable for geometry optimization,
     /// molecular dynamics, phonon or transition state search runs.
     /// A value which is less than or equal to zero indicates that no updates will be performed.
     #[keyword_display(field = "BACKUP_INTERVAL")]
-    BackupInterval(i64),
-    // This keyword specifies the number of geometry optimization or molecular
-    // dynamics iterations between updates of the backup restart files.
-    #[keyword_display(field = "NUM_BACKUP_ITER")]
-    NumBackupIter(u64),
+    BackupInterval(
+        #[pest_ast(inner(
+            rule(Rule::backup_interval),
+            with(span_into_backup_interval),
+            with(Result::unwrap)
+        ))]
+        i64,
+    ),
+}
+
+impl<'a> ConsumeKVPairs<'a> for BackUpSetting {
+    type Item = BackUpSetting;
+
+    fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
+        let num_backup_iter_id = pairs
+            .iter()
+            .position(|p| p.keyword().as_str().to_lowercase() == "num_backup_iter");
+        let backup_interval_id = pairs
+            .iter()
+            .position(|p| p.keyword().as_str().to_lowercase() == "backup_interval");
+        match (num_backup_iter_id, backup_interval_id) {
+            (None, None) => None,
+            (None, Some(n)) | (Some(n), None) => {
+                let to_use = pairs[n];
+                let kvpair = to_use.to_string();
+                let mut parse = ParamParser::parse(Rule::backup_setting, &kvpair).unwrap();
+                Some(BackUpSetting::from_pest(&mut parse).unwrap())
+            }
+            (Some(n), Some(b)) => {
+                let to_use = if n > b { pairs[b] } else { pairs[n] };
+                let kvpair = to_use.to_string();
+                let mut parse = ParamParser::parse(Rule::backup_setting, &kvpair).unwrap();
+                Some(BackUpSetting::from_pest(&mut parse).unwrap())
+            }
+        }
+    }
+}
+
+fn span_into_num_backup_iter(span: Span) -> Result<u64, <u64 as FromStr>::Err> {
+    let to_lower = span.as_str().to_lowercase();
+    let binding = to_lower.replace("num_backup_iter", "").replace(":", "");
+    let trim = binding.trim();
+    trim.parse::<u64>()
+}
+
+fn span_into_backup_interval(span: Span) -> Result<i64, <i64 as FromStr>::Err> {
+    let to_lower = span.as_str().to_lowercase();
+    to_lower
+        .replace("backup_interval", "")
+        .replace(":", "")
+        .trim()
+        .parse::<i64>()
 }
 
 impl Default for BackUpSetting {
     fn default() -> Self {
         Self::NumBackupIter(5)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::parser::{ParamParser, Rule};
+
+    use super::BackUpSetting;
+
+    #[test]
+    fn backup_setting() {
+        let input = "Backup_interval : 5";
+        let mut parse = ParamParser::parse(Rule::backup_setting, input).unwrap();
+        dbg!(&parse);
+        let num_backup_iter = BackUpSetting::from_pest(&mut parse).unwrap();
+        dbg!(num_backup_iter);
+        let input = "Num_backup_Iter : 1";
+        let mut parse = ParamParser::parse(Rule::backup_setting, input).unwrap();
+        dbg!(&parse);
+        let num_backup_iter = BackUpSetting::from_pest(&mut parse).unwrap();
+        dbg!(num_backup_iter);
     }
 }

--- a/castep-param-io/src/param/general/backup_setting.rs
+++ b/castep-param-io/src/param/general/backup_setting.rs
@@ -54,7 +54,7 @@ pub enum BackUpSetting {
 impl<'a> ConsumeKVPairs<'a> for BackUpSetting {
     type Item = BackUpSetting;
 
-    fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
+    fn find_from_pairs(pairs: &'a [crate::parser::ParamItems<'a>]) -> Option<Self::Item> {
         let num_backup_iter_id = pairs
             .iter()
             .position(|p| p.keyword().to_lowercase() == "num_backup_iter");

--- a/castep-param-io/src/param/general/calculate_props.rs
+++ b/castep-param-io/src/param/general/calculate_props.rs
@@ -1,7 +1,11 @@
-use crate::param::KeywordDisplay;
+use crate::{
+    param::KeywordDisplay,
+    parser::{data_type::Logical, Rule},
+};
 
 use castep_param_derive::{KeywordDisplay, ParamDisplay};
 use derive_builder::Builder;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 #[derive(
@@ -40,9 +44,13 @@ pub struct CalculateProperties {
     Deserialize,
     Default,
     KeywordDisplay,
+    FromPest,
 )]
 #[keyword_display(field="CALCULATE_STRESS",from=bool,value=bool)]
-pub struct CalculateStress(bool);
+#[pest_ast(rule(Rule::calc_stress))]
+pub struct CalculateStress(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);
 #[derive(
     Debug,
     Clone,
@@ -56,9 +64,13 @@ pub struct CalculateStress(bool);
     Deserialize,
     Default,
     KeywordDisplay,
+    FromPest,
 )]
 #[keyword_display(field="CALCULATE_DENSDIFF",from=bool,value=bool)]
-pub struct CalculateDensdiff(bool);
+#[pest_ast(rule(Rule::calc_densdiff))]
+pub struct CalculateDensdiff(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);
 #[derive(
     Debug,
     Clone,
@@ -72,9 +84,14 @@ pub struct CalculateDensdiff(bool);
     Deserialize,
     Default,
     KeywordDisplay,
+    FromPest,
 )]
 #[keyword_display(field="CALCULATE_ELF",from=bool,value=bool)]
-pub struct CalculateELF(bool);
+#[pest_ast(rule(Rule::calc_elf))]
+pub struct CalculateELF(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);
+
 #[derive(
     Debug,
     Clone,
@@ -88,13 +105,23 @@ pub struct CalculateELF(bool);
     Deserialize,
     Default,
     KeywordDisplay,
+    FromPest,
 )]
 #[keyword_display(field="CALCULATE_HIRSHFELD", from=bool, value=bool)]
-pub struct CalculateHirshfeld(bool);
+#[pest_ast(rule(Rule::calc_hirshfeld))]
+pub struct CalculateHirshfeld(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);
 
 #[cfg(test)]
 mod test {
-    use crate::param::general::calculate_props::CalculatePropertiesBuilder;
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::{
+        param::general::calculate_props::CalculatePropertiesBuilder,
+        parser::{ParamFile, ParamParser, Rule},
+    };
 
     use super::CalculateProperties;
 
@@ -109,5 +136,23 @@ mod test {
             .unwrap();
         let target = "CALCULATE_STRESS : false\nCALCULATE_DENSDIFF : true";
         assert_eq!(target, p.to_string());
+    }
+    #[test]
+    fn calc_props_parsing() {
+        let input = [
+            "calculate_stress : true",
+            "calculate_ELF : true",
+            "calculate_densdiff : True",
+            "calculate_hirshfeld : false",
+        ];
+        input.iter().for_each(|&l| {
+            let parse = ParamParser::parse(Rule::kv_pair, l);
+            dbg!(parse);
+        });
+        let all = input.join("\n");
+        let mut parse = ParamParser::parse(Rule::param_file, &all).unwrap();
+        dbg!(&parse);
+        let file = ParamFile::from_pest(&mut parse);
+        dbg!(file);
     }
 }

--- a/castep-param-io/src/param/general/calculate_props.rs
+++ b/castep-param-io/src/param/general/calculate_props.rs
@@ -1,11 +1,11 @@
 use crate::{
     param::KeywordDisplay,
-    parser::{data_type::Logical, ConsumeKVPairs, Rule},
+    parser::{data_type::Logical, Rule},
 };
 use from_pest::FromPest;
 use pest::Parser;
 
-use castep_param_derive::{BuildFromPairs, KeywordDisplay, ParamDisplay};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay, ParamDisplay, StructBuildFromPairs};
 use derive_builder::Builder;
 use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
     Default,
     Builder,
     ParamDisplay,
+    StructBuildFromPairs,
 )]
 #[builder(setter(into, strip_option), default)]
 pub struct CalculateProperties {
@@ -31,23 +32,6 @@ pub struct CalculateProperties {
     pub densdiff: Option<CalculateDensdiff>,
     pub elf: Option<CalculateELF>,
     pub hirshfeld: Option<CalculateHirshfeld>,
-}
-
-impl<'a> ConsumeKVPairs<'a> for CalculateProperties {
-    type Item = Self;
-
-    fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
-        let stress = CalculateStress::find_from_pairs(pairs);
-        let densdiff = CalculateDensdiff::find_from_pairs(pairs);
-        let elf = CalculateELF::find_from_pairs(pairs);
-        let hirshfeld = CalculateHirshfeld::find_from_pairs(pairs);
-        Some(Self {
-            stress,
-            densdiff,
-            elf,
-            hirshfeld,
-        })
-    }
 }
 
 #[derive(
@@ -174,13 +158,13 @@ mod test {
             "calculate_hirshfeld : false",
         ];
         input.iter().for_each(|&l| {
-            let parse = ParamParser::parse(Rule::kv_pair, l);
-            dbg!(parse);
+            let parse = ParamParser::parse(Rule::kv_pair, l).is_ok();
+            assert!(parse);
         });
         let all = input.join("\n");
         let mut parse = ParamParser::parse(Rule::param_file, &all).unwrap();
         dbg!(&parse);
         let file = ParamFile::from_pest(&mut parse);
-        dbg!(file);
+        dbg!(file.is_ok());
     }
 }

--- a/castep-param-io/src/param/general/calculate_props.rs
+++ b/castep-param-io/src/param/general/calculate_props.rs
@@ -1,9 +1,11 @@
 use crate::{
     param::KeywordDisplay,
-    parser::{data_type::Logical, Rule},
+    parser::{data_type::Logical, ConsumeKVPairs, Rule},
 };
+use from_pest::FromPest;
+use pest::Parser;
 
-use castep_param_derive::{KeywordDisplay, ParamDisplay};
+use castep_param_derive::{BuildFromPairs, KeywordDisplay, ParamDisplay};
 use derive_builder::Builder;
 use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
@@ -31,6 +33,23 @@ pub struct CalculateProperties {
     pub hirshfeld: Option<CalculateHirshfeld>,
 }
 
+impl<'a> ConsumeKVPairs<'a> for CalculateProperties {
+    type Item = Self;
+
+    fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
+        let stress = CalculateStress::find_from_pairs(pairs);
+        let densdiff = CalculateDensdiff::find_from_pairs(pairs);
+        let elf = CalculateELF::find_from_pairs(pairs);
+        let hirshfeld = CalculateHirshfeld::find_from_pairs(pairs);
+        Some(Self {
+            stress,
+            densdiff,
+            elf,
+            hirshfeld,
+        })
+    }
+}
+
 #[derive(
     Debug,
     Clone,
@@ -45,9 +64,11 @@ pub struct CalculateProperties {
     Default,
     KeywordDisplay,
     FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="CALCULATE_STRESS",from=bool,value=bool)]
 #[pest_ast(rule(Rule::calc_stress))]
+#[pest_rule(rule=Rule::calc_stress, keyword="CALCULATE_STRESS")]
 pub struct CalculateStress(
     #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
 );
@@ -65,12 +86,15 @@ pub struct CalculateStress(
     Default,
     KeywordDisplay,
     FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="CALCULATE_DENSDIFF",from=bool,value=bool)]
 #[pest_ast(rule(Rule::calc_densdiff))]
+#[pest_rule(rule=Rule::calc_densdiff, keyword="CALCULATE_DENSDIFF")]
 pub struct CalculateDensdiff(
     #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
 );
+
 #[derive(
     Debug,
     Clone,
@@ -85,9 +109,11 @@ pub struct CalculateDensdiff(
     Default,
     KeywordDisplay,
     FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="CALCULATE_ELF",from=bool,value=bool)]
 #[pest_ast(rule(Rule::calc_elf))]
+#[pest_rule(rule=Rule::calc_elf, keyword="CALCULATE_ELF")]
 pub struct CalculateELF(
     #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
 );
@@ -106,9 +132,11 @@ pub struct CalculateELF(
     Default,
     KeywordDisplay,
     FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="CALCULATE_HIRSHFELD", from=bool, value=bool)]
 #[pest_ast(rule(Rule::calc_hirshfeld))]
+#[pest_rule(rule=Rule::calc_hirshfeld, keyword="CALCULATE_HIRSHFELD")]
 pub struct CalculateHirshfeld(
     #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
 );

--- a/castep-param-io/src/param/general/castep_task.rs
+++ b/castep-param-io/src/param/general/castep_task.rs
@@ -1,7 +1,11 @@
-
-use castep_param_derive::KeywordDisplay;
+use crate::parser::span_into_str;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay, ParamEnumFromStr};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::Rule;
 
 #[derive(
     Debug,
@@ -16,30 +20,47 @@ use serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
     KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+    ParamEnumFromStr,
 )]
 #[keyword_display(field = "TASK")]
 #[non_exhaustive]
+#[pest_rule(rule=Rule::task, keyword="TASK")]
+#[pest_ast(rule(Rule::task))]
 pub enum CastepTask {
-    BandStructure,        // calculates band structure properties.
+    #[pest_ast(inner(
+        rule(Rule::tasks),
+        with(span_into_str),
+        with(CastepTask::from_str),
+        with(Option::unwrap)
+    ))]
+    BandStructure, // calculates band structure properties.
     GeometryOptimization, // searches for a minimum energy structure.
     #[default]
     SinglePoint, // performs a single-point energy calculation.
-                          //  TODO: Future
-                          // MolecularDynamics,      // performs a molecular dynamics calculation.
-                          // Optics,                 // calculates optical properties.
-                          // Phonon, // performs a linear response calculation to determine phonon frequencies and eigenvectors.
-                          // Efield, // performs an electric field linear response calculation to determine dielectric permittivity and polarizability.
-                          // PhononEfield, // performs a linear response calculation to determine phonon frequencies and eigenvectors, and an electric field linear response calculation to determine dielectric permittivity and polarizability.
-                          // TransitionStateSearch, // performs a transition-state search.
-                          // MagRes,       // performs an NMR calculation.
-                          // Elnes,        // performs core level spectroscopy calculation.
-                          // ElectronicSpectroscopy, // performs electronic spectroscopy calculation.
-                          // Autosolvation, // performs a free energy of solvation calculation.
+    //  TODO: Future
+    MolecularDynamics,      // performs a molecular dynamics calculation.
+    Optics,                 // calculates optical properties.
+    Phonon, // performs a linear response calculation to determine phonon frequencies and eigenvectors.
+    Efield, // performs an electric field linear response calculation to determine dielectric permittivity and polarizability.
+    PhononEfield, // performs a linear response calculation to determine phonon frequencies and eigenvectors, and an electric field linear response calculation to determine dielectric permittivity and polarizability.
+    TransitionStateSearch, // performs a transition-state search.
+    MagRes,       // performs an NMR calculation.
+    Elnes,        // performs core level spectroscopy calculation.
+    ElectronicSpectroscopy, // performs electronic spectroscopy calculation.
+    Autosolvation, // performs a free energy of solvation calculation.
 }
 
 #[cfg(test)]
 mod test {
-    use crate::param::KeywordDisplay;
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::{
+        param::KeywordDisplay,
+        parser::{ParamParser, Rule},
+    };
 
     use super::CastepTask;
 
@@ -51,5 +72,17 @@ mod test {
         assert_eq!("TASK : BandStructure", bandstr.output());
         let geom_opt = CastepTask::GeometryOptimization;
         assert_eq!("TASK : GeometryOptimization", geom_opt.output());
+        let magres = CastepTask::MagRes;
+        let binding = magres.output();
+        let mut parse = ParamParser::parse(Rule::task, &binding).unwrap();
+        dbg!(&parse);
+        // parse.into_iter().for_each(|pair| {
+        //     let span = pair.as_span();
+        //     let mut inner = pair.clone().into_inner();
+        //     let inner = &mut inner;
+        //     dbg!(inner.next());
+        // });
+        let parsed_task = CastepTask::from_pest(&mut parse).unwrap();
+        println!("{}", parsed_task.output())
     }
 }

--- a/castep-param-io/src/param/general/charge_unit.rs
+++ b/castep-param-io/src/param/general/charge_unit.rs
@@ -1,8 +1,13 @@
+use from_pest::FromPest;
+use pest::Parser;
 use std::fmt::{Display, Write};
 
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use pest::Span;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::Rule;
 
 #[derive(
     Debug,
@@ -17,12 +22,27 @@ use serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
     KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field = "CHARGE_UNIT", direct_display = false)]
+#[pest_ast(rule(Rule::charge_unit))]
+#[pest_rule(rule=Rule::charge_unit, keyword="CHARGE_UNIT")]
 pub enum ChargeUnit {
     #[default]
+    #[pest_ast(inner(rule(Rule::charge_unit_value), with(span_into_charge_unit)))]
     E,
     C,
+}
+
+fn span_into_charge_unit(span: Span<'_>) -> ChargeUnit {
+    let value = span.as_str().to_lowercase();
+    let matched = match value.as_str() {
+        "e" => Some(ChargeUnit::E),
+        "c" => Some(ChargeUnit::C),
+        _ => None,
+    };
+    matched.unwrap()
 }
 
 impl Display for ChargeUnit {

--- a/castep-param-io/src/param/general/checkpoint.rs
+++ b/castep-param-io/src/param/general/checkpoint.rs
@@ -1,13 +1,33 @@
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::{span_into_str, Rule};
+
 #[derive(
-    Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, KeywordDisplay,
+    Debug,
+    Clone,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(borrowed_value=str, field="CHECKPOINT", from=String, default_value="test.check".to_string())]
+#[pest_ast(rule(Rule::checkpoint))]
+#[pest_rule(rule=Rule::checkpoint, keyword="CHECKPOINT")]
 /// This keyword contains a string which specifies the name of file to which checkpoint (continuation) data are to be written.
 /// # Default
 /// `seedname.check`
 /// # Example
 /// `CHECKPOINT : test.check`
-pub struct Checkpoint(String);
+pub struct Checkpoint(
+    #[pest_ast(inner(rule(Rule::checkpoint_file), with(span_into_str), with(String::from)))] String,
+);

--- a/castep-param-io/src/param/general/comment.rs
+++ b/castep-param-io/src/param/general/comment.rs
@@ -1,6 +1,10 @@
-
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
+
+use crate::parser::{span_into_str, Rule};
 
 #[derive(
     Debug,
@@ -14,6 +18,28 @@ use serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
     Hash,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="COMMENT", from=String, borrowed_value=str)]
-pub struct Comment(String);
+#[pest_ast(rule(Rule::param_comment))]
+#[pest_rule(rule=Rule::param_comment, keyword="COMMENT")]
+pub struct Comment(#[pest_ast(inner(with(span_into_str), with(String::from)))] String);
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::parser::{ParamParser, Rule};
+
+    use super::Comment;
+
+    #[test]
+    fn comment_parse() {
+        let input = "COMMENT : Calculation from Rhino 5.999\n";
+        let mut parse = ParamParser::parse(Rule::param_comment, input).unwrap();
+        let comment = Comment::from_pest(&mut parse).unwrap();
+        dbg!(comment);
+    }
+}

--- a/castep-param-io/src/param/general/continuation.rs
+++ b/castep-param-io/src/param/general/continuation.rs
@@ -31,11 +31,11 @@ pub enum ContinueReuse {
 impl<'a> ConsumeKVPairs<'a> for ContinueReuse {
     type Item = Self;
 
-    fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
-        let cont_id = pairs
+    fn find_from_pairs(items: &'a [crate::parser::ParamItems<'a>]) -> Option<Self::Item> {
+        let cont_id = items
             .iter()
             .position(|p| p.keyword().to_lowercase() == "continuation");
-        let reuse_id = pairs
+        let reuse_id = items
             .iter()
             .position(|p| p.keyword().to_lowercase() == "reuse");
         let to_use = match (cont_id, reuse_id) {
@@ -50,8 +50,7 @@ impl<'a> ConsumeKVPairs<'a> for ContinueReuse {
             }
         };
         to_use.map(|id| {
-            let kvpair = pairs[id].to_string();
-            dbg!(&kvpair);
+            let kvpair = items[id].to_string();
             let mut parse = ParamParser::parse(Rule::continue_reuse, &kvpair).unwrap();
             Self::from_pest(&mut parse).unwrap()
         })

--- a/castep-param-io/src/param/general/continuation.rs
+++ b/castep-param-io/src/param/general/continuation.rs
@@ -1,15 +1,61 @@
 use castep_param_derive::KeywordDisplay;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::{span_into_str, ConsumeKVPairs, ParamParser, Rule};
+
 #[derive(
-    Debug, Clone, Hash, Serialize, Deserialize, KeywordDisplay, PartialEq, Eq, PartialOrd, Ord,
+    Debug,
+    Clone,
+    Hash,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    FromPest,
 )]
 #[keyword_display(specified_fields = true)]
+#[pest_ast(rule(Rule::continue_reuse))]
 pub enum ContinueReuse {
     #[keyword_display(field = "CONTINUATION")]
     Continuation(Continuation),
     #[keyword_display(field = "REUSE")]
     Reuse(Reuse),
+}
+
+impl<'a> ConsumeKVPairs<'a> for ContinueReuse {
+    type Item = Self;
+
+    fn find_from_pairs(pairs: &'a [crate::parser::KVPair<'a>]) -> Option<Self::Item> {
+        let cont_id = pairs
+            .iter()
+            .position(|p| p.keyword().to_lowercase() == "continuation");
+        let reuse_id = pairs
+            .iter()
+            .position(|p| p.keyword().to_lowercase() == "reuse");
+        let to_use = match (cont_id, reuse_id) {
+            (None, None) => None,
+            (None, Some(n)) | (Some(n), None) => Some(n),
+            (Some(c), Some(r)) => {
+                if c > r {
+                    Some(c)
+                } else {
+                    Some(r)
+                }
+            }
+        };
+        to_use.map(|id| {
+            let kvpair = pairs[id].to_string();
+            dbg!(&kvpair);
+            let mut parse = ParamParser::parse(Rule::continue_reuse, &kvpair).unwrap();
+            Self::from_pest(&mut parse).unwrap()
+        })
+    }
 }
 
 impl Default for ContinueReuse {
@@ -42,12 +88,48 @@ impl From<Reuse> for ContinueReuse {
     Eq,
     PartialOrd,
     Ord,
+    FromPest,
 )]
 #[keyword_display(field = "CONTINUATION")]
+#[pest_ast(rule(Rule::continuation))]
 pub enum Continuation {
+    #[pest_ast(inner(
+        rule(Rule::continuation_default),
+        with(span_into_str),
+        with(Continuation::from_str_default),
+        with(Option::unwrap)
+    ))]
     #[default]
     Default,
-    File(String),
+    File(
+        #[pest_ast(inner(rule(Rule::continuation_file), with(span_into_str), with(String::from)))]
+        String,
+    ),
+}
+
+impl<'a> From<Span<'a>> for Continuation {
+    fn from(value: Span<'a>) -> Self {
+        let mut parse = ParamParser::parse(Rule::continuation, value.as_str()).unwrap();
+        Self::from_pest(&mut parse).unwrap()
+    }
+}
+
+impl Continuation {
+    fn from_str_default(input: &str) -> Option<Self> {
+        if input.to_lowercase() == "default" {
+            Some(Self::Default)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_file(&self) -> Option<&String> {
+        if let Self::File(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(
@@ -62,10 +144,102 @@ pub enum Continuation {
     Eq,
     PartialOrd,
     Ord,
+    FromPest,
 )]
 #[keyword_display(field = "REUSE")]
+#[pest_ast(rule(Rule::reuse))]
 pub enum Reuse {
+    #[pest_ast(inner(
+        rule(Rule::reuse_default),
+        with(span_into_str),
+        with(Reuse::from_str_default),
+        with(Option::unwrap)
+    ))]
     #[default]
     Default,
-    File(String),
+    File(
+        #[pest_ast(inner(rule(Rule::reuse_file), with(span_into_str), with(String::from)))] String,
+    ),
+}
+
+impl Reuse {
+    fn from_str_default(input: &str) -> Option<Self> {
+        if input.to_lowercase() == "default" {
+            Some(Self::Default)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_file(&self) -> Option<&String> {
+        if let Self::File(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::{
+        param::{ContinueReuse, KeywordDisplay, Reuse},
+        parser::{ParamParser, Rule},
+    };
+
+    use super::Continuation;
+
+    #[test]
+    fn continuation_parse() {
+        let input = "continuation : default\r\n";
+        let mut parse = ParamParser::parse(Rule::continuation, input).unwrap();
+        let cont = Continuation::from_pest(&mut parse);
+        assert!(cont.is_ok());
+        let input = "continuation : seed.castep\n";
+        let mut parse = ParamParser::parse(Rule::continuation, input).unwrap();
+        let cont = Continuation::from_pest(&mut parse);
+        assert!(cont.is_ok());
+        assert!(cont.unwrap().as_file().is_some_and(|x| x == "seed.castep"));
+    }
+    #[test]
+    fn reuse_parse() {
+        let input = "reuse : default\r\n";
+        let mut parse = ParamParser::parse(Rule::reuse, input).unwrap();
+        let cont = Reuse::from_pest(&mut parse);
+        assert!(cont.is_ok());
+        let input = "reuse : seed.castep\n";
+        let mut parse = ParamParser::parse(Rule::reuse, input).unwrap();
+        let cont = Reuse::from_pest(&mut parse);
+        assert!(cont.is_ok());
+        assert!(cont.unwrap().as_file().is_some_and(|x| x == "seed.castep"));
+    }
+    #[test]
+    fn cr_parse() {
+        let input = "continuation : default\r\n";
+        let mut parse = ParamParser::parse(Rule::continue_reuse, input).unwrap();
+        let cont = ContinueReuse::from_pest(&mut parse);
+        dbg!(&cont);
+        assert!(cont.is_ok());
+        let input = "continuation : seed.castep\n";
+        let mut parse = ParamParser::parse(Rule::continue_reuse, input).unwrap();
+        let cont = ContinueReuse::from_pest(&mut parse);
+        dbg!(&cont);
+        assert!(cont.is_ok());
+        let input = "reuse : default\r\n";
+        let mut parse = ParamParser::parse(Rule::continue_reuse, input).unwrap();
+        dbg!(&parse);
+        let cont = ContinueReuse::from_pest(&mut parse);
+        dbg!(&cont);
+        assert!(cont.is_ok());
+        let input = "reuse : NP22_single_0";
+        let mut parse = ParamParser::parse(Rule::continue_reuse, input).unwrap();
+        dbg!(&parse);
+        let cont = ContinueReuse::from_pest(&mut parse);
+        dbg!(&cont);
+        assert!(cont.is_ok());
+        println!("{}", cont.unwrap().output());
+    }
 }

--- a/castep-param-io/src/param/general/iprint.rs
+++ b/castep-param-io/src/param/general/iprint.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
+use crate::parser::Rule;
 use castep_param_derive::KeywordDisplay;
+use pest::Span;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 #[derive(
@@ -16,8 +19,10 @@ use serde::{Deserialize, Serialize};
     KeywordDisplay,
     Serialize,
     Deserialize,
+    FromPest,
 )]
 #[keyword_display(field = "IPRINT", direct_display = false)]
+#[pest_ast(rule(Rule::iprint))]
 /// This keyword controls the level of verbosity of the output. Possible
 ///  values range from 0, which produces minimal output, to 3,
 /// which corresponds to full debugging output.
@@ -26,11 +31,24 @@ use serde::{Deserialize, Serialize};
 /// # Example
 /// `IPRINT : 1`
 pub enum IPrint {
+    #[pest_ast(inner(rule(Rule::iprint_value), with(span_into_iprint)))]
     Minimal,
     #[default]
     Default,
     Verbose,
     Full,
+}
+
+fn span_into_iprint(span: Span<'_>) -> IPrint {
+    let value = span.as_str();
+    let matched = match value {
+        "0" => Some(IPrint::Minimal),
+        "1" => Some(IPrint::Default),
+        "2" => Some(IPrint::Verbose),
+        "3" => Some(IPrint::Full),
+        _ => None,
+    };
+    matched.expect("Always correct from parsed value.")
 }
 
 impl Display for IPrint {

--- a/castep-param-io/src/param/general/iprint.rs
+++ b/castep-param-io/src/param/general/iprint.rs
@@ -1,8 +1,9 @@
 use std::fmt::Display;
 
 use crate::parser::Rule;
-use castep_param_derive::KeywordDisplay;
-use pest::Span;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::{Parser, Span};
 use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +21,11 @@ use serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
     FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field = "IPRINT", direct_display = false)]
 #[pest_ast(rule(Rule::iprint))]
+#[pest_rule(rule=Rule::iprint, keyword="IPRINT")]
 /// This keyword controls the level of verbosity of the output. Possible
 ///  values range from 0, which produces minimal output, to 3,
 /// which corresponds to full debugging output.

--- a/castep-param-io/src/param/general/mod.rs
+++ b/castep-param-io/src/param/general/mod.rs
@@ -1,5 +1,5 @@
-use super::{KeywordDisplay, ListFields};
-use castep_param_derive::ParamDisplay;
+use super::KeywordDisplay;
+use castep_param_derive::{ParamDisplay, StructBuildFromPairs};
 use serde::{Deserialize, Serialize};
 
 mod backup_setting;
@@ -55,6 +55,7 @@ pub use write_props::*;
     Deserialize,
     Builder,
     ParamDisplay,
+    StructBuildFromPairs,
 )]
 #[builder(setter(into, strip_option), default)]
 /// Keywords that belong to general category.
@@ -80,34 +81,9 @@ pub struct General {
     pub write_checkpoint: Option<WriteCheckpoint>,
     #[param_display(display=to_string())]
     pub calculate_props: Option<CalculateProperties>, // Default to all false
+    #[param_display(display=to_string())]
     pub write_props: Option<WriteProperties>, // Default to all false
 }
-
-// impl ListFields for General {
-//     fn list_fields() -> Vec<String> {
-//     "task",
-//     "comment",
-//     "continuation",
-//     "reuse",
-//     "backup",
-//     "charge_unit",
-//     #[param_display(use_ref = true)]
-//     "checkpoint",
-//     "data_distribution",
-//     "iprint",
-//     "opt_strategy",
-//     "page_wvfns",
-//     "print_clock",
-//     "print_memory_usage",
-//     "rand_seed",
-//     "run_time",
-//     "stop",
-//     "write_checkpoint",
-//     #[param_display(display=to_string())]
-//     "calculate_props",
-//     "write_props",
-//     }
-// }
 
 #[cfg(test)]
 mod test {

--- a/castep-param-io/src/param/general/mod.rs
+++ b/castep-param-io/src/param/general/mod.rs
@@ -1,4 +1,4 @@
-use super::KeywordDisplay;
+use super::{KeywordDisplay, ListFields};
 use castep_param_derive::ParamDisplay;
 use serde::{Deserialize, Serialize};
 
@@ -82,6 +82,32 @@ pub struct General {
     pub calculate_props: Option<CalculateProperties>, // Default to all false
     pub write_props: Option<WriteProperties>, // Default to all false
 }
+
+// impl ListFields for General {
+//     fn list_fields() -> Vec<String> {
+//     "task",
+//     "comment",
+//     "continuation",
+//     "reuse",
+//     "backup",
+//     "charge_unit",
+//     #[param_display(use_ref = true)]
+//     "checkpoint",
+//     "data_distribution",
+//     "iprint",
+//     "opt_strategy",
+//     "page_wvfns",
+//     "print_clock",
+//     "print_memory_usage",
+//     "rand_seed",
+//     "run_time",
+//     "stop",
+//     "write_checkpoint",
+//     #[param_display(display=to_string())]
+//     "calculate_props",
+//     "write_props",
+//     }
+// }
 
 #[cfg(test)]
 mod test {

--- a/castep-param-io/src/param/general/opt_strategy.rs
+++ b/castep-param-io/src/param/general/opt_strategy.rs
@@ -1,7 +1,9 @@
-
-use castep_param_derive::KeywordDisplay;
+use crate::parser::Rule;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
-
 
 #[derive(
     Debug,
@@ -16,8 +18,12 @@ use serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
     KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field = "OPT_STRATEGY")]
+#[pest_ast(rule(Rule::opt_strategy))]
+#[pest_rule(rule=Rule::opt_strategy, keyword="OPT_STRATEGY")]
 /// This parameter determines the optimization strategy used when there are multiple strategies available for the selected algorithm and they have differing costs in terms of memory usage and performance. Available options are:
 /// - Speed - uses the optimization strategy which maximizes performance at the cost of additional memory usage.
 /// - Default - uses the optimization strategy that best balances performance and memory usage.
@@ -27,8 +33,20 @@ use serde::{Deserialize, Serialize};
 /// # Example
 /// `OPT_STRATEGY : Memory`
 pub enum OptStrategy {
+    #[pest_ast(inner(rule(Rule::opt_strategy_value), with(span_into_opt_strategy)))]
     Speed,
     #[default]
     Default,
     Memory,
+}
+
+fn span_into_opt_strategy(span: Span<'_>) -> OptStrategy {
+    let value = span.as_str().to_lowercase();
+    match value.as_str() {
+        "speed" => Some(OptStrategy::Speed),
+        "default" => Some(OptStrategy::Default),
+        "memory" => Some(OptStrategy::Memory),
+        _ => None,
+    }
+    .expect("Always correct from parsed value.")
 }

--- a/castep-param-io/src/param/general/page_wvfns.rs
+++ b/castep-param-io/src/param/general/page_wvfns.rs
@@ -1,7 +1,10 @@
-
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::{data_type::Integer, Rule};
 
 ///This keyword controls the paging of wavefunctions to disk in order to save memory. Available options are:
 /// - > 0 - all wavefunctions requiring more memory than this value in megabytes will be paged to disk.
@@ -20,9 +23,15 @@ use serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
     KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="PAGE_WVFNS",from=i64,value=i64)]
-pub struct PageWvfns(i64);
+#[pest_ast(rule(Rule::page_wvfns))]
+#[pest_rule(rule=Rule::page_wvfns, keyword="PAGE_WVFNS")]
+pub struct PageWvfns(
+    #[pest_ast(inner(with(Integer::new), with(i64::try_from), with(Result::unwrap)))] i64,
+);
 
 impl From<i32> for PageWvfns {
     fn from(value: i32) -> Self {

--- a/castep-param-io/src/param/general/print_clock.rs
+++ b/castep-param-io/src/param/general/print_clock.rs
@@ -1,8 +1,29 @@
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::{data_type::Logical, Rule};
+
 #[derive(
-    Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, KeywordDisplay,
+    Debug,
+    Hash,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="PRINT_CLOCK",from=bool,value=bool, default_value=true)]
-pub struct PrintClock(bool);
+#[pest_ast(rule(Rule::print_clock))]
+#[pest_rule(rule=Rule::print_clock, keyword="PRINT_CLOCK")]
+pub struct PrintClock(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);

--- a/castep-param-io/src/param/general/print_memory_usage.rs
+++ b/castep-param-io/src/param/general/print_memory_usage.rs
@@ -1,8 +1,29 @@
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::{data_type::Logical, Rule};
+
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="PRINT_MEMORY_USAGE",from=bool,value=bool, default_value=true)]
-pub struct PrintMemoryUsage(bool);
+#[pest_ast(rule(Rule::print_memory_usage))]
+#[pest_rule(rule=Rule::print_memory_usage, keyword="PRINT_MEMORY_USAGE")]
+pub struct PrintMemoryUsage(
+    #[pest_ast(inner(rule(Rule::logical), with(Logical::from), with(Logical::into)))] bool,
+);

--- a/castep-param-io/src/param/general/rand_seed.rs
+++ b/castep-param-io/src/param/general/rand_seed.rs
@@ -1,8 +1,10 @@
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
 use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::parser::{span_into_str, Rule};
+use crate::parser::{data_type::Integer, Rule};
 
 #[derive(
     Debug,
@@ -18,11 +20,13 @@ use crate::parser::{span_into_str, Rule};
     Hash,
     KeywordDisplay,
     FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="RAND_SEED",from=i64,value=i64)]
 #[pest_ast(rule(Rule::rand_seed))]
+#[pest_rule(rule=Rule::rand_seed, keyword="RAND_SEED")]
 pub struct RandSeed(
-    #[pest_ast(inner(with(span_into_str), with(str::parse::<i64>), with(Result::unwrap))) ] i64,
+    #[pest_ast(inner(with(Integer::new), with(i64::try_from), with(Result::unwrap)))] i64,
 );
 
 #[cfg(test)]

--- a/castep-param-io/src/param/general/rand_seed.rs
+++ b/castep-param-io/src/param/general/rand_seed.rs
@@ -1,7 +1,8 @@
-
 use castep_param_derive::KeywordDisplay;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::{span_into_str, Rule};
 
 #[derive(
     Debug,
@@ -16,6 +17,30 @@ use serde::{Deserialize, Serialize};
     Default,
     Hash,
     KeywordDisplay,
+    FromPest,
 )]
 #[keyword_display(field="RAND_SEED",from=i64,value=i64)]
-pub struct RandSeed(i64);
+#[pest_ast(rule(Rule::rand_seed))]
+pub struct RandSeed(
+    #[pest_ast(inner(with(span_into_str), with(str::parse::<i64>), with(Result::unwrap))) ] i64,
+);
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::{
+        param::RandSeed,
+        parser::{ParamParser, Rule},
+    };
+
+    #[test]
+    fn parse_randseed() {
+        let input = "rand_seed : 9";
+        let mut parse = ParamParser::parse(Rule::rand_seed, input).unwrap();
+        println!("{:?}", parse);
+        let rand_seed = RandSeed::from_pest(&mut parse).unwrap();
+        println!("{:?}", rand_seed);
+    }
+}

--- a/castep-param-io/src/param/general/run_time.rs
+++ b/castep-param-io/src/param/general/run_time.rs
@@ -1,7 +1,8 @@
-
 use castep_param_derive::KeywordDisplay;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::{data_type::Integer, Rule};
 
 /// This keyword specifies the maximum run time for the job, in seconds. If the RUN_TIME is greater than zero, the job will exit cleanly before the specified time has elapsed, leaving as little unused time as possible.
 /// If RUN_TIME is less than or equal to zero, no time limit will be imposed on the run.
@@ -22,6 +23,10 @@ use serde::{Deserialize, Serialize};
     PartialOrd,
     Ord,
     KeywordDisplay,
+    FromPest,
 )]
 #[keyword_display(field="RUN_TIME",from=i64,value=i64)]
-pub struct RunTime(i64);
+#[pest_ast(rule(Rule::run_time))]
+pub struct RunTime(
+    #[pest_ast(inner(with(Integer::new), with(i64::try_from), with(Result::unwrap)))] i64,
+);

--- a/castep-param-io/src/param/general/run_time.rs
+++ b/castep-param-io/src/param/general/run_time.rs
@@ -1,4 +1,6 @@
-use castep_param_derive::KeywordDisplay;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::Parser;
 use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
@@ -24,9 +26,11 @@ use crate::parser::{data_type::Integer, Rule};
     Ord,
     KeywordDisplay,
     FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field="RUN_TIME",from=i64,value=i64)]
 #[pest_ast(rule(Rule::run_time))]
+#[pest_rule(rule=Rule::run_time,keyword="RUN_TIME")]
 pub struct RunTime(
     #[pest_ast(inner(with(Integer::new), with(i64::try_from), with(Result::unwrap)))] i64,
 );

--- a/castep-param-io/src/param/general/stop.rs
+++ b/castep-param-io/src/param/general/stop.rs
@@ -1,5 +1,8 @@
+use from_pest::FromPest;
+use pest::Parser;
 use std::{fmt::Display, marker::PhantomData};
 
+use castep_param_derive::BuildFromPairs;
 use pest::Span;
 use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
@@ -19,6 +22,7 @@ use crate::{param::KeywordDisplay, parser::Rule};
     PartialOrd,
     Ord,
     FromPest,
+    BuildFromPairs,
 )]
 /// This keyword, if present, will cause the current run to be aborted as if RUN_TIME had been exceeded.
 ///
@@ -27,7 +31,8 @@ use crate::{param::KeywordDisplay, parser::Rule};
 /// This keyword is valid only when the input file is reread. It is ignored if it is present at the start of a run.
 /// # Example
 /// `STOP`
-#[pest_ast(rule(Rule::kv_pair))]
+#[pest_ast(rule(Rule::param_item))]
+#[pest_rule(rule=Rule::param_item, keyword= "STOP")]
 pub struct Stop(#[pest_ast(inner(rule(Rule::stop), with(span_into_phantom)))] PhantomData<String>);
 
 fn span_into_phantom(_span: Span<'_>) -> PhantomData<String> {
@@ -46,5 +51,23 @@ impl KeywordDisplay for Stop {
     }
     fn output(&self) -> String {
         self.field()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::parser::{ParamParser, Rule};
+
+    use super::Stop;
+
+    #[test]
+    fn stop_parse() {
+        let input = "STOP";
+        let mut parse = ParamParser::parse(Rule::param_item, input).unwrap();
+        let stop = Stop::from_pest(&mut parse).unwrap();
+        dbg!(stop);
     }
 }

--- a/castep-param-io/src/param/general/stop.rs
+++ b/castep-param-io/src/param/general/stop.rs
@@ -1,11 +1,24 @@
-use std::fmt::Display;
+use std::{fmt::Display, marker::PhantomData};
 
+use pest::Span;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{param::KeywordDisplay, parser::Rule};
 
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    FromPest,
 )]
 /// This keyword, if present, will cause the current run to be aborted as if RUN_TIME had been exceeded.
 ///
@@ -14,7 +27,13 @@ use crate::param::KeywordDisplay;
 /// This keyword is valid only when the input file is reread. It is ignored if it is present at the start of a run.
 /// # Example
 /// `STOP`
-pub struct Stop;
+#[pest_ast(rule(Rule::kv_pair))]
+pub struct Stop(#[pest_ast(inner(rule(Rule::stop), with(span_into_phantom)))] PhantomData<String>);
+
+fn span_into_phantom(_span: Span<'_>) -> PhantomData<String> {
+    PhantomData
+}
+
 impl Display for Stop {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("")

--- a/castep-param-io/src/param/general/write_checkpoint.rs
+++ b/castep-param-io/src/param/general/write_checkpoint.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 
-use castep_param_derive::KeywordDisplay;
-use pest::Span;
+use castep_param_derive::{BuildFromPairs, KeywordDisplay};
+use from_pest::FromPest;
+use pest::{Parser, Span};
 use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +21,11 @@ use crate::parser::Rule;
     Deserialize,
     KeywordDisplay,
     FromPest,
+    BuildFromPairs,
 )]
 #[keyword_display(field = "WRITE_CHECKPOINT")]
 #[pest_ast(rule(Rule::write_checkpoint))]
+#[pest_rule(rule=Rule::write_checkpoint, keyword="WRITE_CHECKPOINT")]
 pub enum WriteCheckpoint {
     Value(WriteCheckpointValue),
     Option(WriteCheckpointOption),
@@ -148,7 +151,7 @@ mod test {
         let binding = write_checkpoint_option.output();
         let mut parse = ParamParser::parse(Rule::write_checkpoint, &binding).unwrap();
         dbg!(&parse);
-        let parsed = WriteCheckpoint::from_pest(&mut parse);
+        let parsed = WriteCheckpoint::from_pest(&mut parse).unwrap();
         dbg!(parsed);
     }
 }

--- a/castep-param-io/src/param/general/write_checkpoint.rs
+++ b/castep-param-io/src/param/general/write_checkpoint.rs
@@ -1,13 +1,28 @@
 use std::fmt::Display;
 
 use castep_param_derive::KeywordDisplay;
+use pest::Span;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
+use crate::parser::Rule;
 
 #[derive(
-    Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, KeywordDisplay,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    KeywordDisplay,
+    FromPest,
 )]
 #[keyword_display(field = "WRITE_CHECKPOINT")]
+#[pest_ast(rule(Rule::write_checkpoint))]
 pub enum WriteCheckpoint {
     Value(WriteCheckpointValue),
     Option(WriteCheckpointOption),
@@ -32,10 +47,22 @@ impl From<WriteCheckpointOption> for WriteCheckpoint {
 }
 
 #[derive(
-    Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    FromPest,
 )]
-
+#[pest_ast(rule(Rule::write_checkpoint_value))]
 pub enum WriteCheckpointValue {
+    #[pest_ast(outer(with(span_into_write_checkpoint_value)))]
     None,
     Minimal,
     Both,
@@ -44,24 +71,42 @@ pub enum WriteCheckpointValue {
     Full,
 }
 
+fn span_into_write_checkpoint_value(span: Span<'_>) -> WriteCheckpointValue {
+    let value = span.as_str().to_lowercase();
+    match value.as_str() {
+        "none" => Some(WriteCheckpointValue::None),
+        "minimal" => Some(WriteCheckpointValue::Minimal),
+        "both" => Some(WriteCheckpointValue::Both),
+        "all" => Some(WriteCheckpointValue::All),
+        "full" => Some(WriteCheckpointValue::Full),
+        _ => None,
+    }
+    .expect("Always correct from parsed result.")
+}
+
 impl Display for WriteCheckpointValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WriteCheckpointValue::None => f.write_str("NONE"),
-            WriteCheckpointValue::Minimal => f.write_str("MINIMAL"),
-            WriteCheckpointValue::Both => f.write_str("bOTH"),
-            WriteCheckpointValue::All => f.write_str("ALL"),
-            WriteCheckpointValue::Full => f.write_str("fULL"),
+            WriteCheckpointValue::None => f.write_str("None"),
+            WriteCheckpointValue::Minimal => f.write_str("Minimal"),
+            WriteCheckpointValue::Both => f.write_str("Both"),
+            WriteCheckpointValue::All => f.write_str("All"),
+            WriteCheckpointValue::Full => f.write_str("Full"),
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, FromPest,
+)]
+#[pest_ast(rule(Rule::write_checkpoint_option))]
 pub enum WriteCheckpointOption {
     Success(WriteCheckpointValue),
     Failure(WriteCheckpointValue),
     Backup(WriteCheckpointValue),
 }
+
+// fn span_into_write_checkpoint_option(span:Span<'_>) -> WriteCheckpointOption
 
 impl Default for WriteCheckpointOption {
     fn default() -> Self {
@@ -81,18 +126,29 @@ impl Display for WriteCheckpointOption {
 
 #[cfg(test)]
 mod test {
-    use crate::param::{general::write_checkpoint::WriteCheckpointOption, KeywordDisplay};
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::{
+        param::{general::write_checkpoint::WriteCheckpointOption, KeywordDisplay},
+        parser::{ParamParser, Rule},
+    };
 
     use super::WriteCheckpoint;
 
     #[test]
     fn write_checkpoint() {
         let write_checkpoint = WriteCheckpoint::default();
-        assert_eq!("WRITE_CHECKPOINT : ALL", write_checkpoint.output());
+        assert_eq!("WRITE_CHECKPOINT : All", write_checkpoint.output());
         let write_checkpoint_option = WriteCheckpoint::Option(WriteCheckpointOption::default());
         assert_eq!(
-            "WRITE_CHECKPOINT : BACKUP=MINIMAL",
+            "WRITE_CHECKPOINT : BACKUP=Minimal",
             write_checkpoint_option.output()
         );
+        let binding = write_checkpoint_option.output();
+        let mut parse = ParamParser::parse(Rule::write_checkpoint, &binding).unwrap();
+        dbg!(&parse);
+        let parsed = WriteCheckpoint::from_pest(&mut parse);
+        dbg!(parsed);
     }
 }

--- a/castep-param-io/src/param/general/write_props.rs
+++ b/castep-param-io/src/param/general/write_props.rs
@@ -1,9 +1,14 @@
-use std::fmt::Display;
-
+use castep_param_derive::{BuildFromPairs, KeywordDisplay, ParamDisplay, StructBuildFromPairs};
 use derive_builder::Builder;
+use from_pest::FromPest;
+use pest::Parser;
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{
+    param::KeywordDisplay,
+    parser::{data_type::Logical, Rule},
+};
 
 #[derive(
     Debug,
@@ -18,79 +23,182 @@ use crate::param::KeywordDisplay;
     Deserialize,
     Default,
     Builder,
+    ParamDisplay,
+    StructBuildFromPairs,
 )]
 #[builder(setter(into, strip_option), default)]
 pub struct WriteProperties {
-    pub orbitals: Option<bool>,
-    pub formatted_elf: Option<bool>,
-    pub formatted_density: Option<bool>,
-    pub formatted_potential: Option<bool>,
+    pub orbitals: Option<WriteOrbitals>,
+    pub formatted_elf: Option<WriteFormattedELF>,
+    pub formatted_density: Option<WriteFormattedDensity>,
+    pub formatted_potential: Option<WriteFormattedPotential>,
 }
 
-impl WriteProperties {
-    pub fn orbitals(&self) -> Option<bool> {
-        self.orbitals
-    }
-
-    pub fn set_orbitals(&mut self, orbitals: Option<bool>) {
-        self.orbitals = orbitals;
-    }
-
-    pub fn formatted_elf(&self) -> Option<bool> {
-        self.formatted_elf
-    }
-
-    pub fn set_formatted_elf(&mut self, formatted_elf: Option<bool>) {
-        self.formatted_elf = formatted_elf;
-    }
-
-    pub fn formatted_density(&self) -> Option<bool> {
-        self.formatted_density
-    }
-
-    pub fn set_formatted_density(&mut self, formatted_density: Option<bool>) {
-        self.formatted_density = formatted_density;
-    }
-
-    pub fn formatted_potential(&self) -> Option<bool> {
-        self.formatted_potential
-    }
-
-    pub fn set_formatted_potential(&mut self, formatted_potential: Option<bool>) {
-        self.formatted_potential = formatted_potential;
-    }
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Default,
+    KeywordDisplay,
+    BuildFromPairs,
+    FromPest,
+)]
+#[keyword_display(field = "WRITE_ORBITALS")]
+#[pest_ast(rule(Rule::write_orbitals))]
+#[pest_rule(rule=Rule::write_orbitals, keyword="WRITE_ORBITALS")]
+pub enum WriteOrbitals {
+    #[pest_ast(inner(
+        rule(Rule::logical),
+        with(Logical::from),
+        with(bool::from),
+        with(WriteOrbitals::from)
+    ))]
+    True,
+    #[default]
+    False,
 }
 
-impl Display for WriteProperties {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let output = [
-            self.orbitals().map(|b| format!("WRITE_ORBITALS : {}", b)),
-            self.formatted_elf
-                .map(|b| format!("WRITE_FORMATTED_ELF : {}", b)),
-            self.formatted_density
-                .map(|b| format!("WRITE_FORMATTED_DENSITY : {}", b)),
-            self.formatted_potential
-                .map(|b| format!("WRITE_FORMATTED_POTENTIAL : {}", b)),
-        ]
-        .into_iter()
-        .flatten()
-        .collect::<Vec<String>>()
-        .join("\n");
-        write!(f, "{}", output)
+impl From<bool> for WriteOrbitals {
+    fn from(value: bool) -> Self {
+        if value {
+            Self::True
+        } else {
+            Self::False
+        }
     }
 }
 
-impl KeywordDisplay for WriteProperties {
-    fn field(&self) -> String {
-        String::new()
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Default,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+)]
+#[keyword_display(field = "WRITE_FORMATTED_ELF")]
+#[pest_ast(rule(Rule::write_formatted_elf))]
+#[pest_rule(rule=Rule::write_formatted_elf, keyword="WRITE_FORMATTED_ELF")]
+pub enum WriteFormattedELF {
+    #[pest_ast(inner(
+        rule(Rule::logical),
+        with(Logical::from),
+        with(bool::from),
+        with(WriteFormattedELF::from)
+    ))]
+    True,
+    #[default]
+    False,
+}
+
+impl From<bool> for WriteFormattedELF {
+    fn from(value: bool) -> Self {
+        match value {
+            true => Self::True,
+            false => Self::False,
+        }
     }
-    fn output(&self) -> String {
-        self.to_string()
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Default,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+)]
+#[keyword_display(field = "WRITE_FORMATTED_DENSITY")]
+#[pest_ast(rule(Rule::write_formatted_density))]
+#[pest_rule(rule=Rule::write_formatted_density, keyword="WRITE_FORMATTED_DENSITY")]
+pub enum WriteFormattedDensity {
+    #[pest_ast(inner(
+        rule(Rule::logical),
+        with(Logical::from),
+        with(bool::from),
+        with(WriteFormattedDensity::from)
+    ))]
+    True,
+    #[default]
+    False,
+}
+
+impl From<bool> for WriteFormattedDensity {
+    fn from(value: bool) -> Self {
+        match value {
+            true => Self::True,
+            false => Self::False,
+        }
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Default,
+    KeywordDisplay,
+    FromPest,
+    BuildFromPairs,
+)]
+#[keyword_display(field = "WRITE_FORMATTED_POTENTIAL")]
+#[pest_ast(rule(Rule::write_formatted_potential))]
+#[pest_rule(rule=Rule::write_formatted_potential, keyword="WRITE_FORMATTED_POTENTIAL")]
+pub enum WriteFormattedPotential {
+    #[pest_ast(inner(
+        rule(Rule::logical),
+        with(Logical::from),
+        with(bool::from),
+        with(WriteFormattedPotential::from)
+    ))]
+    True,
+    #[default]
+    False,
+}
+
+impl From<bool> for WriteFormattedPotential {
+    fn from(value: bool) -> Self {
+        match value {
+            true => Self::True,
+            false => Self::False,
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::param::{WriteFormattedDensity, WriteFormattedELF, WriteFormattedPotential};
+
     use super::WriteProperties;
 
     #[test]
@@ -98,9 +206,9 @@ mod test {
         let write_prop = WriteProperties::default();
         assert_eq!("", write_prop.to_string());
         let mut write_prop = WriteProperties::default();
-        write_prop.set_formatted_density(Some(true));
-        write_prop.set_formatted_elf(Some(true));
-        write_prop.set_formatted_potential(Some(false));
+        write_prop.formatted_density = Some(WriteFormattedDensity::True);
+        write_prop.formatted_elf = Some(WriteFormattedELF::True);
+        write_prop.formatted_potential = Some(WriteFormattedPotential::False);
         let target = r#"WRITE_FORMATTED_ELF : true
 WRITE_FORMATTED_DENSITY : true
 WRITE_FORMATTED_POTENTIAL : false"#;

--- a/castep-param-io/src/param/general/write_props.rs
+++ b/castep-param-io/src/param/general/write_props.rs
@@ -101,9 +101,9 @@ mod test {
         write_prop.set_formatted_density(Some(true));
         write_prop.set_formatted_elf(Some(true));
         write_prop.set_formatted_potential(Some(false));
-        let target = r#"WRITE_FORMATTED_ELF : TRUE
-WRITE_FORMATTED_DENSITY : TRUE
-WRITE_FORMATTED_POTENTIAL : FALSE"#;
+        let target = r#"WRITE_FORMATTED_ELF : true
+WRITE_FORMATTED_DENSITY : true
+WRITE_FORMATTED_POTENTIAL : false"#;
         assert_eq!(target, write_prop.to_string());
     }
 }

--- a/castep-param-io/src/param/mod.rs
+++ b/castep-param-io/src/param/mod.rs
@@ -57,3 +57,7 @@ pub trait KeywordDisplay: Display {
         format!("{} : {}", self.field(), self)
     }
 }
+
+pub trait ListFields {
+    fn list_fields() -> Vec<String>;
+}

--- a/castep-param-io/src/param/pseudopotentials/mod.rs
+++ b/castep-param-io/src/param/pseudopotentials/mod.rs
@@ -1,3 +1,4 @@
+use castep_param_derive::StructBuildFromPairs;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -25,6 +26,7 @@ mod relativistic_treatment;
     Ord,
     Builder,
     Default,
+    StructBuildFromPairs,
 )]
 #[builder(
     setter(into, strip_option),

--- a/castep-param-io/src/param/pseudopotentials/pspot_beta_phi_type.rs
+++ b/castep-param-io/src/param/pseudopotentials/pspot_beta_phi_type.rs
@@ -1,10 +1,28 @@
 use std::fmt::Display;
 
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::KeywordDisplay;
+use crate::parser::Rule;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    FromPest,
+    BuildFromPairs,
+)]
 /// This keyword controls the representation of the nonlocal part of the pseudopotential used for calculation of the <β|ϕ> overlaps.
 /// Available options are:
 /// - RECIPROCAL - reciprocal space nonlocal pseudopotentials
@@ -15,14 +33,30 @@ use crate::param::KeywordDisplay;
 /// The default is the value of `PSPOT_NONLOCAL_TYPE`
 /// # Example
 /// `PSPOT_BETA_PHI_TYPE : REAL`
+#[pest_ast(rule(Rule::pspot_beta_phi_type))]
+#[pest_rule(rule=Rule::pspot_beta_phi_type,keyword="PSPOT_BETA_PHI_TYPE")]
 pub enum PSPotBetaPhiType {
+    #[pest_ast(inner(rule(Rule::pspot_beta_phi_types), with(from_span)))]
     Reciprocal,
     Real,
 }
 
+fn from_span(span: Span<'_>) -> PSPotBetaPhiType {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "reciprocal" => Some(PSPotBetaPhiType::Reciprocal),
+        "real" => Some(PSPotBetaPhiType::Real),
+        _ => None,
+    }
+    .expect("Always correct")
+}
+
 impl Display for PSPotBetaPhiType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", format!("{:?}", self).to_uppercase())
+        match self {
+            PSPotBetaPhiType::Reciprocal => f.write_str("reciprocal"),
+            PSPotBetaPhiType::Real => f.write_str("real"),
+        }
     }
 }
 

--- a/castep-param-io/src/param/pseudopotentials/pspot_nonlocal_type.rs
+++ b/castep-param-io/src/param/pseudopotentials/pspot_nonlocal_type.rs
@@ -1,11 +1,28 @@
 use std::fmt::Display;
 
+use crate::parser::Rule;
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::KeywordDisplay;
 
 #[derive(
-    Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword controls the representation of the nonlocal part of the pseudopotential.
 /// Available options are:
@@ -15,15 +32,31 @@ use crate::param::KeywordDisplay;
 /// The default is the value of `RECIPROCAL`.
 /// # Example
 /// `PSPOT_NONLOCAL_TYPE : REAL`
+#[pest_ast(rule(Rule::pspot_nonlocal_type))]
+#[pest_rule(rule=Rule::pspot_nonlocal_type,keyword="PSPOT_NONLOCAL_TYPE")]
 pub enum PSPotNonlocalType {
+    #[pest_ast(inner(rule(Rule::pspot_nonlocal_types), with(from_span)))]
     #[default]
     Reciprocal,
     Real,
 }
 
+fn from_span(span: Span<'_>) -> PSPotNonlocalType {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "reciprocal" => Some(PSPotNonlocalType::Reciprocal),
+        "real" => Some(PSPotNonlocalType::Real),
+        _ => None,
+    }
+    .expect("Always correct")
+}
+
 impl Display for PSPotNonlocalType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", format!("{:?}", self).to_uppercase())
+        match self {
+            PSPotNonlocalType::Reciprocal => f.write_str("reciprocal"),
+            PSPotNonlocalType::Real => f.write_str("real"),
+        }
     }
 }
 

--- a/castep-param-io/src/param/pseudopotentials/relativistic_treatment.rs
+++ b/castep-param-io/src/param/pseudopotentials/relativistic_treatment.rs
@@ -1,5 +1,10 @@
 use std::fmt::Display;
 
+use crate::parser::Rule;
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::KeywordDisplay;
@@ -15,9 +20,24 @@ use crate::param::KeywordDisplay;
 /// # Example
 /// `RELATIVISTIC_TREATMENT : ZORA`
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash, Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
+#[pest_ast(rule(Rule::relativistic_treatment))]
+#[pest_rule(rule=Rule::relativistic_treatment,keyword="RELATIVISTIC_TREATMENT")]
 pub enum RelativisticTreatment {
+    #[pest_ast(inner(rule(Rule::relativistic_treatments), with(from_span)))]
     Schroedinger,
     Zora,
     #[default]
@@ -25,13 +45,25 @@ pub enum RelativisticTreatment {
     Dirac,
 }
 
+fn from_span(span: Span<'_>) -> RelativisticTreatment {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "schroedinger" => Some(RelativisticTreatment::Schroedinger),
+        "zora" => Some(RelativisticTreatment::Zora),
+        "koelling-harmon" => Some(RelativisticTreatment::KoellingHarmon),
+        "dirac" => Some(RelativisticTreatment::Dirac),
+        _ => None,
+    }
+    .expect("Always correct")
+}
+
 impl Display for RelativisticTreatment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RelativisticTreatment::Schroedinger => f.write_str("sCHROEDINGER"),
-            RelativisticTreatment::Zora => f.write_str("ZORA"),
-            RelativisticTreatment::KoellingHarmon => f.write_str("KOELLING-HARMON"),
-            RelativisticTreatment::Dirac => f.write_str("DIRAC"),
+            RelativisticTreatment::Schroedinger => f.write_str("schroedinger"),
+            RelativisticTreatment::Zora => f.write_str("zora"),
+            RelativisticTreatment::KoellingHarmon => f.write_str("koelling-harmon"),
+            RelativisticTreatment::Dirac => f.write_str("dirac"),
         }
     }
 }

--- a/castep-param-io/src/param/units/energy_unit.rs
+++ b/castep-param-io/src/param/units/energy_unit.rs
@@ -1,15 +1,14 @@
 use from_pest::FromPest;
 use pest::Parser;
+use pest::Span;
 use std::fmt::Display;
 
 use castep_param_derive::BuildFromPairs;
 use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    param::KeywordDisplay,
-    parser::{span_into_str, Rule},
-};
+use crate::{param::KeywordDisplay, parser::Rule};
+
 #[derive(
     Debug,
     Clone,
@@ -33,8 +32,7 @@ use crate::{
 pub enum EnergyUnit {
     #[pest_ast(inner(
         rule(Rule::energy_units),
-        with(span_into_str),
-        with(EnergyUnit::from_str),
+        with(EnergyUnit::from_span),
         with(Option::unwrap)
     ))]
     Hartree,
@@ -55,6 +53,32 @@ pub enum EnergyUnit {
     Wavenumber,
     Kelvin,
 }
+
+impl EnergyUnit {
+    pub fn from_span(span: Span<'_>) -> Option<EnergyUnit> {
+        let input = span.as_str();
+        match input.to_lowercase().as_str() {
+            "ha" => Some(EnergyUnit::Hartree),
+            "mha" => Some(EnergyUnit::Millihartree),
+            "ev" => Some(EnergyUnit::ElectronVolt),
+            "mev" => Some(EnergyUnit::MillielectronVolt),
+            "ry" => Some(EnergyUnit::Rydberg),
+            "mry" => Some(EnergyUnit::Millirydberg),
+            "kj/mol" => Some(EnergyUnit::KilojoulesPerMole),
+            "kcal/mol" => Some(EnergyUnit::KilocaloriesPerMole),
+            "j" => Some(EnergyUnit::Joules),
+            "erg" => Some(EnergyUnit::Erg),
+            "hz" => Some(EnergyUnit::Hertz),
+            "mhz" => Some(EnergyUnit::Megahertz),
+            "ghz" => Some(EnergyUnit::Gigahertz),
+            "thz" => Some(EnergyUnit::Terahertz),
+            "cm-1" => Some(EnergyUnit::Wavenumber),
+            "k" => Some(EnergyUnit::Kelvin),
+            _ => None,
+        }
+    }
+}
+
 impl Display for EnergyUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -81,29 +105,5 @@ impl Display for EnergyUnit {
 impl KeywordDisplay for EnergyUnit {
     fn field(&self) -> String {
         "ENERGY_UNIT".to_string()
-    }
-}
-
-impl EnergyUnit {
-    fn from_str(input: &str) -> Option<Self> {
-        match input {
-            "ha" => Some(EnergyUnit::Hartree),
-            "mha" => Some(EnergyUnit::Millihartree),
-            "eV" => Some(EnergyUnit::ElectronVolt),
-            "meV" => Some(EnergyUnit::MillielectronVolt),
-            "ry" => Some(EnergyUnit::Rydberg),
-            "mry" => Some(EnergyUnit::Millirydberg),
-            "kj/mol" => Some(EnergyUnit::KilojoulesPerMole),
-            "kcal/mol" => Some(EnergyUnit::KilocaloriesPerMole),
-            "j" => Some(EnergyUnit::Joules),
-            "erg" => Some(EnergyUnit::Erg),
-            "hz" => Some(EnergyUnit::Hertz),
-            "mhz" => Some(EnergyUnit::Megahertz),
-            "ghz" => Some(EnergyUnit::Gigahertz),
-            "thz" => Some(EnergyUnit::Terahertz),
-            "cm-1" => Some(EnergyUnit::Wavenumber),
-            "k" => Some(EnergyUnit::Kelvin),
-            _ => None,
-        }
     }
 }

--- a/castep-param-io/src/param/units/force_constant_unit.rs
+++ b/castep-param-io/src/param/units/force_constant_unit.rs
@@ -66,3 +66,21 @@ impl KeywordDisplay for ForceConstantUnit {
         "FORCE_CONSTANT_UNIT".to_string()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::parser::{ParamParser, Rule};
+
+    use super::ForceConstantUnit;
+
+    #[test]
+    fn force_constant_unit_parse() {
+        let input = "force_constant_unit : hartree/bohr**2";
+        let mut parse = ParamParser::parse(Rule::force_constant_unit, input).unwrap();
+        let unit = ForceConstantUnit::from_pest(&mut parse).unwrap();
+        dbg!(unit);
+    }
+}

--- a/castep-param-io/src/param/units/force_constant_unit.rs
+++ b/castep-param-io/src/param/units/force_constant_unit.rs
@@ -1,3 +1,8 @@
+use crate::parser::Rule;
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
@@ -5,17 +10,44 @@ use serde::{Deserialize, Serialize};
 use crate::param::KeywordDisplay;
 
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
+#[pest_ast(rule(Rule::force_constant_unit))]
+#[pest_rule(rule=Rule::force_constant_unit, keyword="FORCE_CONSTANT_UNIT")]
 /// This keyword specifies the units in which force constants will be reported.
 /// # Example
 /// `FORCE_CONSTANT_UNIT : n/m`
 pub enum ForceConstantUnit {
+    #[pest_ast(inner(rule(Rule::force_constant_units), with(from_span)))]
     HartreePerBohr2,
     #[default]
     ElectronVoltsPerAng2,
     NewtonPerMeter,
     DynesPerCentimeter,
+}
+
+fn from_span(span: Span<'_>) -> ForceConstantUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "hartree/bohr**2" => Some(ForceConstantUnit::HartreePerBohr2),
+        "ev/ang**2" => Some(ForceConstantUnit::ElectronVoltsPerAng2),
+        "n/m" => Some(ForceConstantUnit::NewtonPerMeter),
+        "dyne/cm" => Some(ForceConstantUnit::DynesPerCentimeter),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for ForceConstantUnit {

--- a/castep-param-io/src/param/units/force_unit.rs
+++ b/castep-param-io/src/param/units/force_unit.rs
@@ -1,20 +1,50 @@
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
 use std::fmt::Display;
 
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{param::KeywordDisplay, parser::Rule};
 
 #[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, Default, Hash, PartialEq, Eq, PartialOrd, Ord,
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Default,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword specifies the units in which force will be reported.
 /// # Example
 /// `FORCE_UNIT : n`
+#[pest_ast(rule(Rule::force_unit))]
+#[pest_rule(rule=Rule::force_unit, keyword="FORCE_UNIT")]
 pub enum ForceUnit {
+    #[pest_ast(inner(rule(Rule::force_units), with(from_span)))]
     HartreePerBohr,
     #[default]
     ElectronVoltsPerAng,
     Newton,
+}
+
+fn from_span(value: Span<'_>) -> ForceUnit {
+    let input = value.as_str();
+    match input.to_lowercase().as_str() {
+        "hartree/bohr" => Some(ForceUnit::HartreePerBohr),
+        "ev/ang" => Some(ForceUnit::ElectronVoltsPerAng),
+        "n" => Some(ForceUnit::Newton),
+        _ => None,
+    }
+    .expect("AlwaysCorrect")
 }
 
 impl Display for ForceUnit {

--- a/castep-param-io/src/param/units/frequency_unit.rs
+++ b/castep-param-io/src/param/units/frequency_unit.rs
@@ -1,16 +1,35 @@
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
 use std::fmt::Display;
 
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{param::KeywordDisplay, parser::Rule};
 
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword specifies the units in which frequency will be reported.
 /// # Example
 /// `FREQUENCY_UNIT : hz`
+#[pest_ast(rule(Rule::frequency_unit))]
+#[pest_rule(rule=Rule::frequency_unit,keyword="FREQUENCY_UNIT")]
 pub enum FrequencyUnit {
+    #[pest_ast(inner(rule(Rule::frequency_units), with(from_span)))]
     Hartree,
     Millihartree,
     ElectronVolt,
@@ -28,6 +47,30 @@ pub enum FrequencyUnit {
     #[default]
     Wavenumber,
     Kelvin,
+}
+
+fn from_span(span: Span<'_>) -> FrequencyUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "ha" => Some(FrequencyUnit::Hartree),
+        "mha" => Some(FrequencyUnit::Millihartree),
+        "ev" => Some(FrequencyUnit::ElectronVolt),
+        "mev" => Some(FrequencyUnit::MillielectronVolt),
+        "ry" => Some(FrequencyUnit::Rydberg),
+        "mry" => Some(FrequencyUnit::Millirydberg),
+        "kj/mol" => Some(FrequencyUnit::KilojoulesPerMole),
+        "kcal/mol" => Some(FrequencyUnit::KilocaloriesPerMole),
+        "j" => Some(FrequencyUnit::Joules),
+        "erg" => Some(FrequencyUnit::Erg),
+        "hz" => Some(FrequencyUnit::Hertz),
+        "mhz" => Some(FrequencyUnit::Megahertz),
+        "ghz" => Some(FrequencyUnit::Gigahertz),
+        "thz" => Some(FrequencyUnit::Terahertz),
+        "cm-1" => Some(FrequencyUnit::Wavenumber),
+        "k" => Some(FrequencyUnit::Kelvin),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for FrequencyUnit {

--- a/castep-param-io/src/param/units/inv_length_unit.rs
+++ b/castep-param-io/src/param/units/inv_length_unit.rs
@@ -1,21 +1,53 @@
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
 use std::fmt::Display;
 
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::KeywordDisplay;
+use crate::parser::Rule;
 
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword specifies the units in which inverse length will be reported.
 /// # Example
 /// `INV_LENGTH_UNIT : 1/nm`
+#[pest_ast(rule(Rule::inv_length_unit))]
+#[pest_rule(rule=Rule::inv_length_unit,keyword="INV_LENGTH_UNIT")]
 pub enum InvLengthUnit {
+    #[pest_ast(inner(rule(Rule::inv_length_units), with(from_span)))]
     Bohr,
     Meter,
     Nanometer,
     #[default]
     Ang,
+}
+
+fn from_span(span: Span<'_>) -> InvLengthUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "1/" => Some(InvLengthUnit::Bohr),
+        "1/m" => Some(InvLengthUnit::Meter),
+        "1/nm" => Some(InvLengthUnit::Nanometer),
+        "1/ang" => Some(InvLengthUnit::Ang),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for InvLengthUnit {

--- a/castep-param-io/src/param/units/inv_length_unit.rs
+++ b/castep-param-io/src/param/units/inv_length_unit.rs
@@ -30,7 +30,11 @@ use crate::parser::Rule;
 #[pest_ast(rule(Rule::inv_length_unit))]
 #[pest_rule(rule=Rule::inv_length_unit,keyword="INV_LENGTH_UNIT")]
 pub enum InvLengthUnit {
-    #[pest_ast(inner(rule(Rule::inv_length_units), with(from_span)))]
+    #[pest_ast(inner(
+        rule(Rule::inv_length_units),
+        with(InvLengthUnit::from_span),
+        with(Option::unwrap)
+    ))]
     Bohr,
     Meter,
     Nanometer,
@@ -38,16 +42,17 @@ pub enum InvLengthUnit {
     Ang,
 }
 
-fn from_span(span: Span<'_>) -> InvLengthUnit {
-    let input = span.as_str();
-    match input.to_lowercase().as_str() {
-        "1/" => Some(InvLengthUnit::Bohr),
-        "1/m" => Some(InvLengthUnit::Meter),
-        "1/nm" => Some(InvLengthUnit::Nanometer),
-        "1/ang" => Some(InvLengthUnit::Ang),
-        _ => None,
+impl InvLengthUnit {
+    pub fn from_span(span: Span<'_>) -> Option<InvLengthUnit> {
+        let input = span.as_str();
+        match input.to_lowercase().as_str() {
+            "1/" => Some(InvLengthUnit::Bohr),
+            "1/m" => Some(InvLengthUnit::Meter),
+            "1/nm" => Some(InvLengthUnit::Nanometer),
+            "1/ang" => Some(InvLengthUnit::Ang),
+            _ => None,
+        }
     }
-    .expect("Always correct")
 }
 
 impl Display for InvLengthUnit {

--- a/castep-param-io/src/param/units/length_unit.rs
+++ b/castep-param-io/src/param/units/length_unit.rs
@@ -1,16 +1,35 @@
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{param::KeywordDisplay, parser::Rule};
 
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword specifies the units in which lengths will be reported.
 /// # Example
 /// `LENGTH_UNIT : bohr`
+#[pest_ast(rule(Rule::length_unit))]
+#[pest_rule(rule=Rule::length_unit,keyword="LENGTH_UNIT")]
 pub enum LengthUnit {
+    #[pest_ast(inner(rule(Rule::length_units), with(from_span)))]
     Bohr,
     BohrA0,
     Meter,
@@ -18,6 +37,20 @@ pub enum LengthUnit {
     Nanometer,
     #[default]
     Ang,
+}
+
+fn from_span(span: Span<'_>) -> LengthUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "bohr" => Some(LengthUnit::Bohr),
+        "a0" => Some(LengthUnit::BohrA0),
+        "m" => Some(LengthUnit::Meter),
+        "cm" => Some(LengthUnit::Centimeter),
+        "nm" => Some(LengthUnit::Nanometer),
+        "ang" => Some(LengthUnit::Ang),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for LengthUnit {

--- a/castep-param-io/src/param/units/mass_unit.rs
+++ b/castep-param-io/src/param/units/mass_unit.rs
@@ -1,21 +1,53 @@
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
 use std::fmt::Display;
 
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
 use crate::param::KeywordDisplay;
+use crate::parser::Rule;
 
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword specifies the units in which masses will be reported.
 /// # Example
 /// `MASS_UNIT : kg`
+#[pest_ast(rule(Rule::mass_unit))]
+#[pest_rule(rule=Rule::mass_unit,keyword="MASS_UNIT")]
 pub enum MassUnit {
+    #[pest_ast(inner(rule(Rule::mass_units), with(from_span)))]
     ElectronMass,
     #[default]
     AtomicMassUnit,
     Kilogram,
     Gram,
+}
+
+fn from_span(span: Span<'_>) -> MassUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "me" => Some(MassUnit::ElectronMass),
+        "amu" => Some(MassUnit::AtomicMassUnit),
+        "kg" => Some(MassUnit::Kilogram),
+        "g" => Some(MassUnit::Gram),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for MassUnit {

--- a/castep-param-io/src/param/units/mod.rs
+++ b/castep-param-io/src/param/units/mod.rs
@@ -1,5 +1,5 @@
 use super::KeywordDisplay;
-use castep_param_derive::ParamDisplay;
+use castep_param_derive::{ParamDisplay, StructBuildFromPairs};
 use derive_builder::Builder;
 
 pub use energy_unit::EnergyUnit;
@@ -41,6 +41,7 @@ mod volume_unit;
     Hash,
     Builder,
     ParamDisplay,
+    StructBuildFromPairs,
 )]
 #[builder(setter(into, strip_option), default)]
 pub struct Units {

--- a/castep-param-io/src/param/units/pressure_unit.rs
+++ b/castep-param-io/src/param/units/pressure_unit.rs
@@ -1,14 +1,34 @@
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
 use std::fmt::Display;
 
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{param::KeywordDisplay, parser::Rule};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    FromPest,
+    BuildFromPairs,
+)]
 /// This keyword specifies the units in which pressure will be reported.
 /// # Example
 /// `PRESSURE_UNIT : atm`
+#[pest_ast(rule(Rule::pressure_unit))]
+#[pest_rule(rule=Rule::pressure_unit,keyword="PRESSURE_UNIT")]
 pub enum PressureUnit {
+    #[pest_ast(inner(rule(Rule::pressure_unit), with(from_span)))]
     HartreePerBohr3,
     ElectronVoltsPerAng3,
     Pascal,
@@ -19,6 +39,18 @@ pub enum PressureUnit {
     Megabar,
 }
 
+fn from_span(span: Span<'_>) -> PressureUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "hartree/bohr**3" => Some(PressureUnit::HartreePerBohr3),
+        "ev/ang**3" => Some(PressureUnit::ElectronVoltsPerAng3),
+        "pa" => Some(PressureUnit::Pascal),
+        "mpa" => Some(PressureUnit::Megapascal),
+        "gpa" => Some(PressureUnit::Gigapascal),
+        _ => None,
+    }
+    .expect("Always correct")
+}
 impl Display for PressureUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/castep-param-io/src/param/units/pressure_unit.rs
+++ b/castep-param-io/src/param/units/pressure_unit.rs
@@ -28,7 +28,7 @@ use crate::{param::KeywordDisplay, parser::Rule};
 #[pest_ast(rule(Rule::pressure_unit))]
 #[pest_rule(rule=Rule::pressure_unit,keyword="PRESSURE_UNIT")]
 pub enum PressureUnit {
-    #[pest_ast(inner(rule(Rule::pressure_unit), with(from_span)))]
+    #[pest_ast(inner(rule(Rule::pressure_units), with(from_span)))]
     HartreePerBohr3,
     ElectronVoltsPerAng3,
     Pascal,

--- a/castep-param-io/src/param/units/time_unit.rs
+++ b/castep-param-io/src/param/units/time_unit.rs
@@ -1,16 +1,35 @@
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
 use std::fmt::Display;
 
+use pest_ast::FromPest;
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{param::KeywordDisplay, parser::Rule};
 
 #[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord, Default,
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword specifies the units in which time will be reported.
 /// # Example
 /// `TIME_UNIT : aut`
+#[pest_ast(rule(Rule::time_unit))]
+#[pest_rule(rule=Rule::time_unit,keyword="TIME_UNIT")]
 pub enum TimeUnit {
+    #[pest_ast(inner(rule(Rule::time_unit), with(from_span)))]
     AtomicUnitOfTime,
     Second,
     Millisecond,
@@ -19,6 +38,21 @@ pub enum TimeUnit {
     #[default]
     Picosecond,
     Femtosecond,
+}
+
+fn from_span(span: Span<'_>) -> TimeUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "aut" => Some(TimeUnit::AtomicUnitOfTime),
+        "s" => Some(TimeUnit::Second),
+        "ms" => Some(TimeUnit::Millisecond),
+        "mus" => Some(TimeUnit::Microsecond),
+        "ns" => Some(TimeUnit::Nanosecond),
+        "ps" => Some(TimeUnit::Picosecond),
+        "fs" => Some(TimeUnit::Femtosecond),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for TimeUnit {

--- a/castep-param-io/src/param/units/time_unit.rs
+++ b/castep-param-io/src/param/units/time_unit.rs
@@ -29,7 +29,7 @@ use crate::{param::KeywordDisplay, parser::Rule};
 #[pest_ast(rule(Rule::time_unit))]
 #[pest_rule(rule=Rule::time_unit,keyword="TIME_UNIT")]
 pub enum TimeUnit {
-    #[pest_ast(inner(rule(Rule::time_unit), with(from_span)))]
+    #[pest_ast(inner(rule(Rule::time_units), with(from_span)))]
     AtomicUnitOfTime,
     Second,
     Millisecond,

--- a/castep-param-io/src/param/units/velocity_unit.rs
+++ b/castep-param-io/src/param/units/velocity_unit.rs
@@ -29,7 +29,7 @@ use crate::{param::KeywordDisplay, parser::Rule};
 #[pest_ast(rule(Rule::velocity_unit))]
 #[pest_rule(rule=Rule::velocity_unit,keyword="VELOCITY_UNIT")]
 pub enum VelocityUnit {
-    #[pest_ast(inner(rule(Rule::velocity_unit), with(from_span)))]
+    #[pest_ast(inner(rule(Rule::velocity_units), with(from_span)))]
     AtomicUnitOfVelocity,
     #[default]
     AngPerPs,

--- a/castep-param-io/src/param/units/velocity_unit.rs
+++ b/castep-param-io/src/param/units/velocity_unit.rs
@@ -1,16 +1,35 @@
+use castep_param_derive::BuildFromPairs;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{param::KeywordDisplay, parser::Rule};
 
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword specifies the units in which velocity will be reported.
 /// # Example
 /// `VELOCITY_UNIT : bohr/fs`
+#[pest_ast(rule(Rule::velocity_unit))]
+#[pest_rule(rule=Rule::velocity_unit,keyword="VELOCITY_UNIT")]
 pub enum VelocityUnit {
+    #[pest_ast(inner(rule(Rule::velocity_unit), with(from_span)))]
     AtomicUnitOfVelocity,
     #[default]
     AngPerPs,
@@ -18,6 +37,20 @@ pub enum VelocityUnit {
     BohrPerPs,
     BohrPerFs,
     MetersPerSecond,
+}
+
+fn from_span(span: Span<'_>) -> VelocityUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "auv" => Some(VelocityUnit::AtomicUnitOfVelocity),
+        "ang/ps" => Some(VelocityUnit::AngPerPs),
+        "ang/fs" => Some(VelocityUnit::AngPerFs),
+        "bohr/ps" => Some(VelocityUnit::BohrPerPs),
+        "bohr/fs" => Some(VelocityUnit::BohrPerFs),
+        "m/s" => Some(VelocityUnit::MetersPerSecond),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for VelocityUnit {

--- a/castep-param-io/src/param/units/volume_unit.rs
+++ b/castep-param-io/src/param/units/volume_unit.rs
@@ -1,4 +1,6 @@
 use std::fmt::Display;
+use pest::Parser;
+use from_pest::FromPest;
 
 use serde::{Deserialize, Serialize};
 

--- a/castep-param-io/src/param/units/volume_unit.rs
+++ b/castep-param-io/src/param/units/volume_unit.rs
@@ -1,24 +1,54 @@
-use std::fmt::Display;
-use pest::Parser;
+use castep_param_derive::BuildFromPairs;
 use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
+use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::param::KeywordDisplay;
+use crate::{param::KeywordDisplay, parser::Rule};
 
 #[derive(
-    Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    FromPest,
+    BuildFromPairs,
 )]
 /// This keyword specifies the units in which volume will be reported.
 /// # Example
 /// ` VOLUME_UNIT : nm**3`
+#[pest_ast(rule(Rule::volume_unit))]
+#[pest_rule(rule=Rule::volume_unit,keyword="VOLUME_UNIT")]
 pub enum VolumeUnit {
+    #[pest_ast(inner(rule(Rule::volume_units), with(from_span)))]
     Bohr3,
     Meter3,
     Centimeter3,
     Nanometer3,
     #[default]
     Ang3,
+}
+
+fn from_span(span: Span<'_>) -> VolumeUnit {
+    let input = span.as_str();
+    match input.to_lowercase().as_str() {
+        "bohr**3" => Some(VolumeUnit::Bohr3),
+        "m**3" => Some(VolumeUnit::Meter3),
+        "cm**3" => Some(VolumeUnit::Centimeter3),
+        "nm**3" => Some(VolumeUnit::Nanometer3),
+        "ang**3" => Some(VolumeUnit::Ang3),
+        _ => None,
+    }
+    .expect("Always correct")
 }
 
 impl Display for VolumeUnit {
@@ -36,5 +66,27 @@ impl Display for VolumeUnit {
 impl KeywordDisplay for VolumeUnit {
     fn field(&self) -> String {
         "VOLUME_UNIT".to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::{
+        param::KeywordDisplay,
+        parser::{ConsumeKVPairs, ParamFile, ParamParser, Rule},
+    };
+
+    use super::VolumeUnit;
+
+    #[test]
+    fn volume_unit_parse() {
+        let input = VolumeUnit::Bohr3.output();
+        let mut parse = ParamParser::parse(Rule::param_file, &input).unwrap();
+        let file = ParamFile::from_pest(&mut parse).unwrap();
+        let unit = VolumeUnit::find_from_pairs(file.items());
+        dbg!(unit);
     }
 }

--- a/castep-param-io/src/parser/data_type/integer.rs
+++ b/castep-param-io/src/parser/data_type/integer.rs
@@ -1,0 +1,44 @@
+use std::str::FromStr;
+
+use pest::Span;
+use pest_ast::FromPest;
+
+use crate::parser::Rule;
+
+#[derive(Debug, Clone, Copy, PartialEq, FromPest)]
+#[pest_ast(rule(Rule::pos_integer))]
+/// Parse result for non-negative integer as u64
+pub struct PosInteger<'a>(#[pest_ast(outer())] Span<'a>);
+
+impl<'a> PosInteger<'a> {
+    pub fn new(span: Span<'a>) -> Self {
+        Self(span)
+    }
+}
+
+impl TryFrom<PosInteger<'_>> for u64 {
+    type Error = <u64 as FromStr>::Err;
+
+    fn try_from(value: PosInteger) -> Result<Self, Self::Error> {
+        value.0.as_str().parse::<u64>()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, FromPest)]
+#[pest_ast(rule(Rule::integer))]
+/// Parse result for integer as i64
+pub struct Integer<'a>(#[pest_ast(outer())] Span<'a>);
+
+impl<'a> Integer<'a> {
+    pub fn new(span: Span<'a>) -> Self {
+        Self(span)
+    }
+}
+
+impl TryFrom<Integer<'_>> for i64 {
+    type Error = <i64 as FromStr>::Err;
+
+    fn try_from(value: Integer) -> Result<Self, Self::Error> {
+        value.0.as_str().parse::<i64>()
+    }
+}

--- a/castep-param-io/src/parser/data_type/logical.rs
+++ b/castep-param-io/src/parser/data_type/logical.rs
@@ -1,0 +1,27 @@
+use pest::Span;
+use pest_ast::FromPest;
+
+use crate::parser::Rule;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPest)]
+#[pest_ast(rule(Rule::logical))]
+pub struct Logical<'a>(#[pest_ast(outer())] Span<'a>);
+
+impl From<Logical<'_>> for bool {
+    fn from(value: Logical<'_>) -> Self {
+        let expr = value.0.as_str().to_lowercase();
+        expr.parse::<bool>()
+            .expect("Always correct from parsed result.")
+    }
+}
+
+impl<'a> From<Span<'a>> for Logical<'a> {
+    fn from(value: Span<'a>) -> Self {
+        Self(value)
+    }
+}
+
+impl<'a> Logical<'a> {
+    pub fn new(span: Span<'a>) -> Self {
+        Self(span)
+    }
+}

--- a/castep-param-io/src/parser/data_type/mod.rs
+++ b/castep-param-io/src/parser/data_type/mod.rs
@@ -1,0 +1,46 @@
+mod real;
+
+mod logical {
+    use pest::Span;
+    use pest_ast::FromPest;
+
+    use crate::parser::{span_into_str, Rule};
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromPest, Default)]
+    #[pest_ast(rule(Rule::logical))]
+    pub struct Logical(
+        #[pest_ast(outer(with(span_into_str), with(str::parse), with(Result::unwrap)))] bool,
+    );
+
+    impl std::ops::Deref for Logical {
+        type Target = bool;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl From<Logical> for bool {
+        fn from(value: Logical) -> Self {
+            value.0
+        }
+    }
+
+    impl From<bool> for Logical {
+        fn from(value: bool) -> Self {
+            Self(value)
+        }
+    }
+
+    impl<'a> From<Span<'a>> for Logical {
+        fn from(value: Span<'a>) -> Self {
+            span_into_str(value)
+                .to_lowercase()
+                .parse::<bool>()
+                .unwrap()
+                .into()
+        }
+    }
+}
+
+pub use logical::Logical;
+pub use real::Real;

--- a/castep-param-io/src/parser/data_type/mod.rs
+++ b/castep-param-io/src/parser/data_type/mod.rs
@@ -1,46 +1,7 @@
+mod integer;
+mod logical;
 mod real;
 
-mod logical {
-    use pest::Span;
-    use pest_ast::FromPest;
-
-    use crate::parser::{span_into_str, Rule};
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromPest, Default)]
-    #[pest_ast(rule(Rule::logical))]
-    pub struct Logical(
-        #[pest_ast(outer(with(span_into_str), with(str::parse), with(Result::unwrap)))] bool,
-    );
-
-    impl std::ops::Deref for Logical {
-        type Target = bool;
-
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl From<Logical> for bool {
-        fn from(value: Logical) -> Self {
-            value.0
-        }
-    }
-
-    impl From<bool> for Logical {
-        fn from(value: bool) -> Self {
-            Self(value)
-        }
-    }
-
-    impl<'a> From<Span<'a>> for Logical {
-        fn from(value: Span<'a>) -> Self {
-            span_into_str(value)
-                .to_lowercase()
-                .parse::<bool>()
-                .unwrap()
-                .into()
-        }
-    }
-}
-
+pub use integer::{Integer, PosInteger};
 pub use logical::Logical;
 pub use real::Real;

--- a/castep-param-io/src/parser/data_type/real.rs
+++ b/castep-param-io/src/parser/data_type/real.rs
@@ -1,0 +1,53 @@
+use pest_ast::FromPest;
+
+use crate::parser::{span_into_str, Rule};
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, FromPest)]
+#[pest_ast(rule(Rule::real))]
+pub struct Real(
+    #[pest_ast(outer(with(span_into_str), with(str::parse::<f64>), with(Result::unwrap)))] pub f64,
+);
+
+impl std::ops::Deref for Real {
+    type Target = f64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+#[cfg(test)]
+mod test {
+    use from_pest::FromPest;
+    use pest::Parser;
+
+    use crate::parser::{data_type::real::Real, ParamParser, Rule};
+
+    #[test]
+    fn rule_real() {
+        let mut tree = ParamParser::parse(Rule::real, "1.6e-5").unwrap();
+        println!("{:?}", tree);
+        let number = Real::from_pest(&mut tree).unwrap();
+        dbg!(number);
+        let mut parse = ParamParser::parse(Rule::real, "1e4").unwrap();
+        let number = Real::from_pest(&mut parse).unwrap();
+        dbg!(number);
+        let mut parse = ParamParser::parse(Rule::real, "-1.6e-4").unwrap();
+        let number = Real::from_pest(&mut parse).unwrap();
+        dbg!(number);
+        let mut parse = ParamParser::parse(Rule::real, "-0.5").unwrap();
+        let number = Real::from_pest(&mut parse).unwrap();
+        dbg!(number);
+        let mut parse = ParamParser::parse(Rule::real, "0.50000000000000000").unwrap();
+        let number = Real::from_pest(&mut parse).unwrap();
+        dbg!(number);
+        let mut parse = ParamParser::parse(Rule::real, ".5").unwrap();
+        let number = Real::from_pest(&mut parse).unwrap();
+        dbg!(number);
+        let mut parse = ParamParser::parse(Rule::real, "-.5").unwrap();
+        let number = Real::from_pest(&mut parse).unwrap();
+        dbg!(number);
+        let mut parse = ParamParser::parse(Rule::real, "-.5e6").unwrap();
+        let number = Real::from_pest(&mut parse).unwrap();
+        dbg!(number);
+    }
+}

--- a/castep-param-io/src/parser/data_type/real.rs
+++ b/castep-param-io/src/parser/data_type/real.rs
@@ -1,20 +1,25 @@
+use pest::Span;
 use pest_ast::FromPest;
 
-use crate::parser::{span_into_str, Rule};
+use crate::parser::Rule;
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, FromPest)]
+#[derive(Debug, Clone, Copy, PartialEq, FromPest)]
 #[pest_ast(rule(Rule::real))]
-pub struct Real(
-    #[pest_ast(outer(with(span_into_str), with(str::parse::<f64>), with(Result::unwrap)))] pub f64,
-);
+pub struct Real<'a>(#[pest_ast(outer())] pub Span<'a>);
 
-impl std::ops::Deref for Real {
-    type Target = f64;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl<'a> Real<'a> {
+    pub fn from_span(span: Span<'a>) -> Self {
+        Real(span)
     }
 }
+
+impl<'a> From<Real<'a>> for f64 {
+    fn from(value: Real<'a>) -> Self {
+        let value = value.0.as_str();
+        value.parse::<f64>().expect("Should be real number")
+    }
+}
+
 #[cfg(test)]
 mod test {
     use from_pest::FromPest;

--- a/castep-param-io/src/parser/general.rs
+++ b/castep-param-io/src/parser/general.rs
@@ -1,15 +1,27 @@
-use crate::param::{BackUpSetting, CastepTask, General, GeneralBuilder};
+use crate::param::{BackUpSetting, CastepTask, Comment, ContinueReuse, General, OptStrategy};
 use crate::parser::ConsumeKVPairs;
 
-use super::KVPair;
+use super::{FromParamFile, KVPair, ParamFile};
 
 #[allow(dead_code)]
-impl General {
-    pub fn build_from_parsed<'a>(parsed_pairs: &'a [KVPair<'a>]) -> Self {
-        GeneralBuilder::default()
-            .task(CastepTask::find_from_pairs(parsed_pairs).unwrap_or_default())
-            .backup(BackUpSetting::find_from_pairs(parsed_pairs).unwrap_or_default())
-            .build()
-            .expect("Error in given fields")
+impl FromParamFile for General {
+    type Item = General;
+    fn build_from_file(file: &ParamFile) -> Self {
+        let parsed_pairs = file.pairs();
+        General {
+            stop: file.stop(),
+            ..General::build_from_parsed(parsed_pairs)
+        }
+    }
+
+    fn build_from_parsed(parsed_pairs: &[KVPair<'_>]) -> Self {
+        General {
+            task: CastepTask::find_from_pairs(parsed_pairs),
+            backup: BackUpSetting::find_from_pairs(parsed_pairs),
+            comment: Comment::find_from_pairs(parsed_pairs),
+            continuation_reuse: ContinueReuse::find_from_pairs(parsed_pairs),
+            opt_strategy: OptStrategy::find_from_pairs(parsed_pairs),
+            ..General::default()
+        }
     }
 }

--- a/castep-param-io/src/parser/general.rs
+++ b/castep-param-io/src/parser/general.rs
@@ -1,0 +1,15 @@
+use crate::param::{BackUpSetting, CastepTask, General, GeneralBuilder};
+use crate::parser::ConsumeKVPairs;
+
+use super::KVPair;
+
+#[allow(dead_code)]
+impl General {
+    pub fn build_from_parsed<'a>(parsed_pairs: &'a [KVPair<'a>]) -> Self {
+        GeneralBuilder::default()
+            .task(CastepTask::find_from_pairs(parsed_pairs).unwrap_or_default())
+            .backup(BackUpSetting::find_from_pairs(parsed_pairs).unwrap_or_default())
+            .build()
+            .expect("Error in given fields")
+    }
+}

--- a/castep-param-io/src/parser/general.rs
+++ b/castep-param-io/src/parser/general.rs
@@ -1,27 +1,2 @@
-use crate::param::{BackUpSetting, CastepTask, Comment, ContinueReuse, General, OptStrategy};
-use crate::parser::ConsumeKVPairs;
 
-use super::{FromParamFile, KVPair, ParamFile};
 
-#[allow(dead_code)]
-impl FromParamFile for General {
-    type Item = General;
-    fn build_from_file(file: &ParamFile) -> Self {
-        let parsed_pairs = file.pairs();
-        General {
-            stop: file.stop(),
-            ..General::build_from_parsed(parsed_pairs)
-        }
-    }
-
-    fn build_from_parsed(parsed_pairs: &[KVPair<'_>]) -> Self {
-        General {
-            task: CastepTask::find_from_pairs(parsed_pairs),
-            backup: BackUpSetting::find_from_pairs(parsed_pairs),
-            comment: Comment::find_from_pairs(parsed_pairs),
-            continuation_reuse: ContinueReuse::find_from_pairs(parsed_pairs),
-            opt_strategy: OptStrategy::find_from_pairs(parsed_pairs),
-            ..General::default()
-        }
-    }
-}

--- a/castep-param-io/src/parser/mod.rs
+++ b/castep-param-io/src/parser/mod.rs
@@ -48,7 +48,7 @@ pub enum ParamItems<'a> {
     Stop,
 }
 
-impl<'a> ParamItems<'a> {
+impl ParamItems<'_> {
     pub fn keyword(&self) -> String {
         match self {
             ParamItems::Pairs(kvpair) => kvpair.keyword().into(),

--- a/castep-param-io/src/parser/mod.rs
+++ b/castep-param-io/src/parser/mod.rs
@@ -4,6 +4,8 @@ use pest::Span;
 use pest_ast::FromPest;
 use pest_derive::Parser;
 
+use crate::param::Stop;
+
 pub mod data_type;
 mod general;
 
@@ -19,6 +21,7 @@ pub fn span_into_str(span: Span) -> &str {
 #[pest_ast(rule(Rule::param_file))]
 pub struct ParamFile<'a> {
     pairs: Vec<KVPair<'a>>,
+    stop: Option<Stop>,
 }
 
 impl<'a> ParamFile<'a> {
@@ -29,36 +32,62 @@ impl<'a> ParamFile<'a> {
     pub fn pairs_mut(&mut self) -> &mut Vec<KVPair<'a>> {
         &mut self.pairs
     }
+
+    pub fn stop(&self) -> Option<Stop> {
+        self.stop
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, FromPest)]
 #[pest_ast(rule(Rule::kv_pair))]
 pub struct KVPair<'a> {
-    #[pest_ast(inner(rule(Rule::keyword)))]
-    keyword: Span<'a>,
+    #[pest_ast(inner(rule(Rule::keyword), with(span_into_str)))]
+    keyword: &'a str,
     #[pest_ast(inner(rule(Rule::value)))]
     value: Span<'a>,
 }
 
+impl PartialOrd for KVPair<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.keyword.partial_cmp(other.keyword)
+    }
+}
+
 impl<'a> KVPair<'a> {
-    pub fn keyword(&self) -> Span<'a> {
+    pub fn keyword(&self) -> &str {
         self.keyword
     }
 
     pub fn value(&self) -> Span<'a> {
         self.value
     }
+
+    /// Sort parsed keyword pairs according to the order of fields in `CastepParam`
+    pub fn ordered_copy(&self) -> Self {
+        // Use enumerate to mark the current order with indices.
+        todo!();
+    }
 }
 
 impl Display for KVPair<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} : {}", self.keyword.as_str(), self.value.as_str())
+        write!(f, "{} : {}", self.keyword, self.value.as_str())
     }
 }
 
 pub trait ConsumeKVPairs<'a> {
     type Item;
     fn find_from_pairs(pairs: &'a [KVPair<'a>]) -> Option<Self::Item>;
+}
+
+pub trait FromParamFile {
+    type Item: Sized;
+    fn build_from_parsed(_parsed_pairs: &[KVPair<'_>]) -> Self::Item {
+        todo!()
+    }
+    fn build_from_file(_file: &ParamFile<'_>) -> Self::Item {
+        unimplemented!()
+    }
 }
 
 #[cfg(test)]
@@ -68,7 +97,7 @@ mod test {
     use from_pest::FromPest;
     use pest::Parser;
 
-    use crate::param::General;
+    use crate::{param::General, parser::FromParamFile};
 
     use super::{ParamFile, ParamParser, Rule};
 
@@ -76,8 +105,9 @@ mod test {
     fn test_param() {
         let param = read_to_string("NP22_single_0.param").unwrap();
         let mut parse = ParamParser::parse(Rule::param_file, &param).unwrap();
-        let mut parsed_param = ParamFile::from_pest(&mut parse).unwrap();
-        let general_section = General::build_from_parsed(parsed_param.pairs_mut());
+        dbg!(&parse);
+        let parsed_param = ParamFile::from_pest(&mut parse).unwrap();
+        let general_section = General::build_from_file(&parsed_param);
         println!("{}", general_section);
     }
 }

--- a/castep-param-io/src/parser/param.pest
+++ b/castep-param-io/src/parser/param.pest
@@ -1,6 +1,43 @@
-number = {ASCII_DIGIT+}
-sign = {"-" | "+"}
-integer = @{ ("-" | "+")? ~ number } 
-real = @{("-" | "+")? ~ number? ~ "." ~ number ~ ^"e" ~ ("-"|"+")? ~ number | 
-sign? ~ number ~ ^"e" ~ sign? ~ number| sign{,1} ~ number? ~ "." ~ number
+WHITESPACE  = _{ " " | NEWLINE }
+COMMENT     =  { "#" ~ ANY* | "!" ~ ANY* }
+number      =  { ASCII_DIGIT+ }
+sign        =  { "-" | "+" }
+integer     = @{ ("-" | "+")? ~ number }
+pos_integer = @{ ("+")? ~ number }
+real        = @{
+    ("-" | "+")? ~ number? ~ "." ~ number ~ ^"e" ~ ("-" | "+")? ~ number
+  | sign? ~ number ~ ^"e" ~ sign? ~ number
+  | sign{,1} ~ number? ~ "." ~ number
 }
+logical     =  { ^"true" | ^"false" }
+string      =  { (!(NEWLINE | number | sign | COMMENT) ~ ANY)* }
+rand_seed   =  { ^"rand_seed" ~ ":" ~ integer }
+param_file  =  { kv_pair* }
+keyword     = @{ (ASCII_ALPHANUMERIC | "_")* }
+value       = @{ logical | real | pos_integer | integer | string }
+kv_pair     =  { keyword ~ WHITESPACE* ~ ":" ~ WHITESPACE* ~ value }
+
+task            = { ^"task" ~ ":" ~ tasks }
+tasks           = {
+    ^"BandStructure"
+  | ^"GeometryOptimization"
+  | ^"SinglePoint"
+  | ^"MolecularDynamics"
+  | ^"Optics"
+  | ^"Phonon"
+  | ^"Efield"
+  | ^"PhononEfield"
+  | ^"TransitionStateSearch"
+  | ^"MagRes"
+  | ^"Elnes"
+  | ^"ElectronicSpectroscopy"
+  | ^"Autosolvation"
+}
+backup_setting  = { backup_interval | num_backup_iter }
+backup_interval = { ^"BACKUP_INTERVAL" ~ ":" ~ integer }
+num_backup_iter = { ^"NUM_BACKUP_ITER" ~ ":" ~ integer }
+
+calc_stress    = { ^"calculate_stress" ~ ":" ~ logical }
+calc_densdiff  = { ^"calculate_densdiff" ~ ":" ~ logical }
+calc_elf       = { ^"calculate_elf" ~ ":" ~ logical }
+calc_hirshfeld = { ^"calculate_hirshfeld" ~ ":" ~ logical }

--- a/castep-param-io/src/parser/param.pest
+++ b/castep-param-io/src/parser/param.pest
@@ -116,3 +116,91 @@ energy_units = {
   | ^"cm-1"
   | ^"k"
 }
+
+force_unit  = { ^"force_unit" ~ ":" ~ force_units }
+force_units = {
+    ^"hartree/bohr"
+  | ^"ev/ang"
+  | ^"n"
+}
+
+force_constant_unit  = { ^"force_constant_unit" ~ ":" ~ force_constant_units }
+force_constant_units = {
+    ^"hartree/bohr**2"
+  | ^"ev/ang**2"
+  | ^"n/m"
+  | ^"dyne/cm"
+}
+
+frequency_unit   = { ^"frequency_unit" ~ ":" ~ frequency_units }
+frequency_units  = {
+    "ha"
+  | "mha"
+  | "ev"
+  | "mev"
+  | "ry"
+  | "mry"
+  | "kj/mol"
+  | "kcal/mol"
+  | "j"
+  | "erg"
+  | "hz"
+  | "mhz"
+  | "ghz"
+  | "thz"
+  | "cm-1"
+  | "k"
+}
+inv_length_unit  = { ^"inv_length_unit" ~ ":" ~ inv_length_units }
+inv_length_units = {
+    "1/"
+  | "1/m"
+  | "1/nm"
+  | "1/ang"
+}
+length_unit      = { ^"length_unit" ~ ":" ~ length_units }
+length_units     = {
+    "bohr"
+  | "a0"
+  | "m"
+  | "cm"
+  | "nm"
+  | "ang"
+}
+mass_unit        = { ^"mass_unit" ~ ":" ~ mass_units }
+mass_units       = {
+    "me"
+  | "amu"
+  | "kg"
+  | "g"
+}
+pressure_unit    = { ^"{pressure_unit}" ~ ":" ~ pressure_units }
+pressure_units   = {
+    "hartree/bohr**3"
+  | "ev/ang**3"
+  | "pa"
+  | "mpa"
+  | "gpa"
+  | "atm"
+  | "bar"
+  | "mbar"
+}
+time_unit        = { ^"{time_unit}" ~ ":" ~ time_units }
+time_units       = {
+    "aut"
+  | "s"
+  | "ms"
+  | "mus"
+  | "ns"
+  | "ps"
+  | "fs"
+}
+velocity_unit    = { ^"{velocity_unit}" ~ ":" ~ velocity_units }
+velocity_units   = {
+    "auv"
+  | "ang/ps"
+  | "ang/fs"
+  | "bohr/ps"
+  | "bohr/fs"
+  | "m/s"
+}

--- a/castep-param-io/src/parser/param.pest
+++ b/castep-param-io/src/parser/param.pest
@@ -1,5 +1,6 @@
-WHITESPACE  = _{ " " | NEWLINE }
+WHITESPACE  = _{ " " | NEWLINE | "\t" }
 COMMENT     =  { "#" ~ ANY* | "!" ~ ANY* }
+anything    =  { (ANY | ASCII_DIGIT)* }
 number      =  { ASCII_DIGIT+ }
 sign        =  { "-" | "+" }
 integer     = @{ ("-" | "+")? ~ number }
@@ -10,15 +11,17 @@ real        = @{
   | sign{,1} ~ number? ~ "." ~ number
 }
 logical     =  { ^"true" | ^"false" }
-string      =  { (!(NEWLINE | number | sign | COMMENT) ~ ANY)* }
-rand_seed   =  { ^"rand_seed" ~ ":" ~ integer }
-param_file  =  { kv_pair* }
-keyword     = @{ (ASCII_ALPHANUMERIC | "_")* }
-value       = @{ logical | real | pos_integer | integer | string }
-kv_pair     =  { keyword ~ WHITESPACE* ~ ":" ~ WHITESPACE* ~ value }
+// strict_string =  { (!(NEWLINE | number | sign | COMMENT) ~ ANY)* }
+string     =  { (!(NEWLINE | COMMENT) ~ ANY)* }
+rand_seed  =  { ^"rand_seed" ~ ":" ~ integer }
+param_file =  { kv_pair* }
+keyword    = @{ (ASCII_ALPHANUMERIC | "_")* }
+value      = @{ EOI | logical | real | pos_integer | integer | string }
+kv_pair    =  { (keyword ~ WHITESPACE* ~ ":" ~ WHITESPACE* ~ value) | stop }
+stop       =  { ^"stop" ~ EOI }
 
-task            = { ^"task" ~ ":" ~ tasks }
-tasks           = {
+task                    = { ^"task" ~ ":" ~ tasks }
+tasks                   = {
     ^"BandStructure"
   | ^"GeometryOptimization"
   | ^"SinglePoint"
@@ -33,6 +36,39 @@ tasks           = {
   | ^"ElectronicSpectroscopy"
   | ^"Autosolvation"
 }
+param_comment           = { ^"comment" ~ ":" ~ anything }
+continue_reuse          = { continuation | reuse }
+continuation            = { ^"continuation" ~ ":" ~ (continuation_default | continuation_file) }
+continuation_default    = { ^"default" }
+continuation_file       = { anything }
+reuse                   = { ^"reuse" ~ ":" ~ (reuse_default | reuse_file) }
+reuse_default           = { ^"default" }
+reuse_file              = { anything }
+charge_unit             = { ^"charge_unit" ~ ":" ~ charge_unit_value }
+charge_unit_value       = { ^"e" | ^"c" }
+checkpoint              = { ^"CHECKPOINT" ~ ":" ~ checkpoint_file }
+checkpoint_file         = { anything }
+data_distribution       = { ^"data_distribution" ~ ":" ~ data_distribution_value }
+data_distribution_value = {
+    ^"Kpoint"
+  | ^"Gvector"
+  | ^"Mixed"
+  | ^"Default"
+}
+iprint                  = { ^"iprint" ~ ":" ~ iprint_value }
+iprint_value            = { "0" | "1" | "2" | "3" }
+opt_strategy            = { ^"opt_strategy" ~ ":" ~ opt_strategy_value }
+opt_strategy_value      = {
+    ^"Speed"
+  | ^"Default"
+  | ^"Memory"
+}
+page_wvfns              = { ^"page_wvfns" ~ ":" ~ page_wvfns_value }
+page_wvfns_value        = { integer }
+print_clock             = { ^"print_clock" ~ ":" ~ logical }
+print_memory_usage      = { ^"print_memory_usage" ~ ":" ~ logical }
+run_time                = { ^"run_time" ~ ":" ~ integer }
+
 backup_setting  = { backup_interval | num_backup_iter }
 backup_interval = { ^"BACKUP_INTERVAL" ~ ":" ~ integer }
 num_backup_iter = { ^"NUM_BACKUP_ITER" ~ ":" ~ integer }
@@ -41,3 +77,23 @@ calc_stress    = { ^"calculate_stress" ~ ":" ~ logical }
 calc_densdiff  = { ^"calculate_densdiff" ~ ":" ~ logical }
 calc_elf       = { ^"calculate_elf" ~ ":" ~ logical }
 calc_hirshfeld = { ^"calculate_hirshfeld" ~ ":" ~ logical }
+
+energy_unit  = { ^"energy_unit" ~ ":" ~ energy_units }
+energy_units = {
+    ^"ha"
+  | ^"mha"
+  | ^"eV"
+  | ^"meV"
+  | ^"ry"
+  | ^"mry"
+  | ^"kj/mol"
+  | ^"kcal/mol"
+  | ^"j"
+  | ^"erg"
+  | ^"hz"
+  | ^"mhz"
+  | ^"ghz"
+  | ^"thz"
+  | ^"cm-1"
+  | ^"k"
+}

--- a/castep-param-io/src/parser/param.pest
+++ b/castep-param-io/src/parser/param.pest
@@ -14,10 +14,11 @@ logical     =  { ^"true" | ^"false" }
 // strict_string =  { (!(NEWLINE | number | sign | COMMENT) ~ ANY)* }
 string     =  { (!(NEWLINE | COMMENT) ~ ANY)* }
 rand_seed  =  { ^"rand_seed" ~ ":" ~ integer }
-param_file =  { kv_pair* }
+param_file =  { param_item* }
 keyword    = @{ (ASCII_ALPHANUMERIC | "_")* }
 value      = @{ EOI | logical | real | pos_integer | integer | string }
-kv_pair    =  { (keyword ~ WHITESPACE* ~ ":" ~ WHITESPACE* ~ value) | stop }
+kv_pair    =  { (keyword ~ WHITESPACE* ~ ":" ~ WHITESPACE* ~ value) }
+param_item =  { kv_pair | stop }
 
 task                     =  { ^"task" ~ ":" ~ tasks }
 tasks                    =  {
@@ -67,7 +68,7 @@ page_wvfns_value         =  { integer }
 print_clock              =  { ^"print_clock" ~ ":" ~ logical }
 print_memory_usage       =  { ^"print_memory_usage" ~ ":" ~ logical }
 run_time                 =  { ^"run_time" ~ ":" ~ integer }
-stop                     =  { ^"stop" ~ EOI }
+stop                     =  { ^"stop" }
 write_checkpoint         =  { ^"write_checkpoint" ~ ":" ~ (write_checkpoint_option | write_checkpoint_value) }
 write_checkpoint_value   =  {
     ^"None"
@@ -87,10 +88,14 @@ backup_setting  = { backup_interval | num_backup_iter }
 backup_interval = { ^"BACKUP_INTERVAL" ~ ":" ~ integer }
 num_backup_iter = { ^"NUM_BACKUP_ITER" ~ ":" ~ integer }
 
-calc_stress    = { ^"calculate_stress" ~ ":" ~ logical }
-calc_densdiff  = { ^"calculate_densdiff" ~ ":" ~ logical }
-calc_elf       = { ^"calculate_elf" ~ ":" ~ logical }
-calc_hirshfeld = { ^"calculate_hirshfeld" ~ ":" ~ logical }
+calc_stress               = { ^"calculate_stress" ~ ":" ~ logical }
+calc_densdiff             = { ^"calculate_densdiff" ~ ":" ~ logical }
+calc_elf                  = { ^"calculate_elf" ~ ":" ~ logical }
+calc_hirshfeld            = { ^"calculate_hirshfeld" ~ ":" ~ logical }
+write_orbitals            = { ^"write_orbitals" ~ ":" ~ logical }
+write_formatted_elf       = { ^"write_formatted_elf" ~ ":" ~ logical }
+write_formatted_density   = { ^"write_formatted_density" ~ ":" ~ logical }
+write_formatted_potential = { ^"write_formatted_potential" ~ ":" ~ logical }
 
 energy_unit  = { ^"energy_unit" ~ ":" ~ energy_units }
 energy_units = {

--- a/castep-param-io/src/parser/param.pest
+++ b/castep-param-io/src/parser/param.pest
@@ -18,10 +18,9 @@ param_file =  { kv_pair* }
 keyword    = @{ (ASCII_ALPHANUMERIC | "_")* }
 value      = @{ EOI | logical | real | pos_integer | integer | string }
 kv_pair    =  { (keyword ~ WHITESPACE* ~ ":" ~ WHITESPACE* ~ value) | stop }
-stop       =  { ^"stop" ~ EOI }
 
-task                    = { ^"task" ~ ":" ~ tasks }
-tasks                   = {
+task                     =  { ^"task" ~ ":" ~ tasks }
+tasks                    =  {
     ^"BandStructure"
   | ^"GeometryOptimization"
   | ^"SinglePoint"
@@ -36,38 +35,53 @@ tasks                   = {
   | ^"ElectronicSpectroscopy"
   | ^"Autosolvation"
 }
-param_comment           = { ^"comment" ~ ":" ~ anything }
-continue_reuse          = { continuation | reuse }
-continuation            = { ^"continuation" ~ ":" ~ (continuation_default | continuation_file) }
-continuation_default    = { ^"default" }
-continuation_file       = { anything }
-reuse                   = { ^"reuse" ~ ":" ~ (reuse_default | reuse_file) }
-reuse_default           = { ^"default" }
-reuse_file              = { anything }
-charge_unit             = { ^"charge_unit" ~ ":" ~ charge_unit_value }
-charge_unit_value       = { ^"e" | ^"c" }
-checkpoint              = { ^"CHECKPOINT" ~ ":" ~ checkpoint_file }
-checkpoint_file         = { anything }
-data_distribution       = { ^"data_distribution" ~ ":" ~ data_distribution_value }
-data_distribution_value = {
+param_comment            =  { ^"comment" ~ ":" ~ anything }
+continue_reuse           =  { continuation | reuse }
+continuation             =  { ^"continuation" ~ ":" ~ (continuation_default | continuation_file) }
+continuation_default     =  { ^"default" }
+continuation_file        =  { anything }
+reuse                    =  { ^"reuse" ~ ":" ~ (reuse_default | reuse_file) }
+reuse_default            =  { ^"default" }
+reuse_file               =  { anything }
+charge_unit              =  { ^"charge_unit" ~ ":" ~ charge_unit_value }
+charge_unit_value        =  { ^"e" | ^"c" }
+checkpoint               =  { ^"CHECKPOINT" ~ ":" ~ checkpoint_file }
+checkpoint_file          =  { anything }
+data_distribution        =  { ^"data_distribution" ~ ":" ~ data_distribution_value }
+data_distribution_value  =  {
     ^"Kpoint"
   | ^"Gvector"
   | ^"Mixed"
   | ^"Default"
 }
-iprint                  = { ^"iprint" ~ ":" ~ iprint_value }
-iprint_value            = { "0" | "1" | "2" | "3" }
-opt_strategy            = { ^"opt_strategy" ~ ":" ~ opt_strategy_value }
-opt_strategy_value      = {
+iprint                   =  { ^"iprint" ~ ":" ~ iprint_value }
+iprint_value             =  { "0" | "1" | "2" | "3" }
+opt_strategy             =  { ^"opt_strategy" ~ ":" ~ opt_strategy_value }
+opt_strategy_value       =  {
     ^"Speed"
   | ^"Default"
   | ^"Memory"
 }
-page_wvfns              = { ^"page_wvfns" ~ ":" ~ page_wvfns_value }
-page_wvfns_value        = { integer }
-print_clock             = { ^"print_clock" ~ ":" ~ logical }
-print_memory_usage      = { ^"print_memory_usage" ~ ":" ~ logical }
-run_time                = { ^"run_time" ~ ":" ~ integer }
+page_wvfns               =  { ^"page_wvfns" ~ ":" ~ page_wvfns_value }
+page_wvfns_value         =  { integer }
+print_clock              =  { ^"print_clock" ~ ":" ~ logical }
+print_memory_usage       =  { ^"print_memory_usage" ~ ":" ~ logical }
+run_time                 =  { ^"run_time" ~ ":" ~ integer }
+stop                     =  { ^"stop" ~ EOI }
+write_checkpoint         =  { ^"write_checkpoint" ~ ":" ~ (write_checkpoint_option | write_checkpoint_value) }
+write_checkpoint_value   =  {
+    ^"None"
+  | ^"Minimal"
+  | ^"Both"
+  | ^"All"
+  | ^"Full"
+}
+write_checkpoint_option  =  { write_checkpoint_options ~ "=" ~ write_checkpoint_value }
+write_checkpoint_options = @{
+    ^"Success"
+  | ^"Failure"
+  | ^"Backup"
+}
 
 backup_setting  = { backup_interval | num_backup_iter }
 backup_interval = { ^"BACKUP_INTERVAL" ~ ":" ~ integer }

--- a/castep-param-io/src/parser/param.pest
+++ b/castep-param-io/src/parser/param.pest
@@ -9,6 +9,7 @@ real        = @{
     ("-" | "+")? ~ number? ~ "." ~ number ~ ^"e" ~ ("-" | "+")? ~ number
   | sign? ~ number ~ ^"e" ~ sign? ~ number
   | sign{,1} ~ number? ~ "." ~ number
+  | number
 }
 logical     =  { ^"true" | ^"false" }
 // strict_string =  { (!(NEWLINE | number | sign | COMMENT) ~ ANY)* }
@@ -132,75 +133,128 @@ force_constant_units = {
   | ^"dyne/cm"
 }
 
-frequency_unit   = { ^"frequency_unit" ~ ":" ~ frequency_units }
-frequency_units  = {
-    "ha"
-  | "mha"
-  | "ev"
-  | "mev"
-  | "ry"
-  | "mry"
-  | "kj/mol"
-  | "kcal/mol"
-  | "j"
-  | "erg"
-  | "hz"
-  | "mhz"
-  | "ghz"
+frequency_unit          = { ^"frequency_unit" ~ ":" ~ frequency_units }
+frequency_units         = {
+    ^"ha"
+  | ^"mha"
+  | ^"ev"
+  | ^"mev"
+  | ^"ry"
+  | ^"mry"
+  | ^"kj/mol"
+  | ^"kcal/mol"
+  | ^"j"
+  | ^"erg"
+  | ^"hz"
+  | ^"mhz"
+  | ^"ghz"
   | "thz"
-  | "cm-1"
-  | "k"
+  | ^"cm-1"
+  | ^"k"
 }
-inv_length_unit  = { ^"inv_length_unit" ~ ":" ~ inv_length_units }
-inv_length_units = {
-    "1/"
-  | "1/m"
-  | "1/nm"
-  | "1/ang"
+inv_length_unit         = { ^"inv_length_unit" ~ ":" ~ inv_length_units }
+inv_length_units        = {
+    ^"1/"
+  | ^"1/m"
+  | ^"1/nm"
+  | ^"1/ang"
 }
-length_unit      = { ^"length_unit" ~ ":" ~ length_units }
-length_units     = {
-    "bohr"
-  | "a0"
-  | "m"
-  | "cm"
-  | "nm"
-  | "ang"
+length_unit             = { ^"length_unit" ~ ":" ~ length_units }
+length_units            = {
+    ^"bohr"
+  | ^"a0"
+  | ^"m"
+  | ^"cm"
+  | ^"nm"
+  | ^"ang"
 }
-mass_unit        = { ^"mass_unit" ~ ":" ~ mass_units }
-mass_units       = {
-    "me"
-  | "amu"
-  | "kg"
-  | "g"
+mass_unit               = { ^"mass_unit" ~ ":" ~ mass_units }
+mass_units              = {
+    ^"me"
+  | ^"amu"
+  | ^"kg"
+  | ^"g"
 }
-pressure_unit    = { ^"{pressure_unit}" ~ ":" ~ pressure_units }
-pressure_units   = {
-    "hartree/bohr**3"
-  | "ev/ang**3"
-  | "pa"
-  | "mpa"
-  | "gpa"
-  | "atm"
-  | "bar"
-  | "mbar"
+pressure_unit           = { ^"pressure_unit" ~ ":" ~ pressure_units }
+pressure_units          = {
+    ^"hartree/bohr**3"
+  | ^"ev/ang**3"
+  | ^"pa"
+  | ^"mpa"
+  | ^"gpa"
+  | ^"atm"
+  | ^"bar"
+  | ^"mbar"
 }
-time_unit        = { ^"{time_unit}" ~ ":" ~ time_units }
-time_units       = {
-    "aut"
-  | "s"
-  | "ms"
-  | "mus"
-  | "ns"
-  | "ps"
-  | "fs"
+time_unit               = { ^"time_unit" ~ ":" ~ time_units }
+time_units              = {
+    ^"aut"
+  | ^"s"
+  | ^"ms"
+  | ^"mus"
+  | ^"ns"
+  | ^"ps"
+  | ^"fs"
 }
-velocity_unit    = { ^"{velocity_unit}" ~ ":" ~ velocity_units }
-velocity_units   = {
-    "auv"
-  | "ang/ps"
-  | "ang/fs"
-  | "bohr/ps"
-  | "bohr/fs"
-  | "m/s"
+velocity_unit           = { ^"velocity_unit" ~ ":" ~ velocity_units }
+velocity_units          = {
+    ^"auv"
+  | ^"ang/ps"
+  | ^"ang/fs"
+  | ^"bohr/ps"
+  | ^"bohr/fs"
+  | ^"m/s"
 }
+volume_unit             = { ^"volume_unit" ~ ":" ~ volume_units }
+volume_units            = {
+    ^"bohr**3"
+  | ^"m**3"
+  | ^"cm**3"
+  | ^"nm**3"
+  | ^"ang**3"
+}
+pspot_beta_phi_type     = { ^"pspot_beta_phi_type" ~ ":" ~ pspot_beta_phi_types }
+pspot_beta_phi_types    = {
+    ^"reciprocal"
+  | ^"real"
+}
+pspot_nonlocal_type     = { ^"pspot_nonlocal_type" ~ ":" ~ pspot_nonlocal_types }
+pspot_nonlocal_types    = {
+    ^"reciprocal"
+  | ^"real"
+}
+relativistic_treatment  = { ^"relativistic_treatment" ~ ":" ~ relativistic_treatments }
+relativistic_treatments = {
+    ^"schroedinger"
+  | ^"zora"
+  | ^"koelling-harmon"
+  | ^"dirac"
+}
+bs_eigenvalue_tol       = { ^"bs_eigenvalue_tol" ~ ":" ~ real ~ bs_eigenvalue_tol_unit }
+bs_eigenvalue_tol_unit  = { energy_units? }
+bs_max_cg_steps         = { ^"bs_max_cg_steps" ~ ":" ~ pos_integer }
+bs_max_iter             = { ^"bs_max_iter" ~ ":" ~ pos_integer }
+bs_nbands               = { ^"bs_nbands" ~ ":" ~ pos_integer }
+bs_re_est_k_scrn        = { ^"bs_re_est_k_scrn" ~ ":" ~ logical }
+bs_extra_bands          = { bs_nextra_bands | bs_perc_extra_bands }
+bs_nextra_bands         = { ^"bs_nextra_bands" ~ ":" ~ pos_integer }
+bs_perc_extra_bands     = { ^"bs_perc_extra_bands" ~ ":" ~ real }
+bs_xc_functional        = { ^"bs_xc_functional" ~ ":" ~ bs_xc_functionals }
+bs_xc_functionals       = {
+    ^"SHF-LDA"
+  | ^"HF-LDA"
+  | ^"lda"
+  | ^"pw91"
+  | ^"pbe"
+  | ^"rpbe"
+  | ^"wc"
+  | ^"pbesol"
+  | ^"hf"
+  | ^"shf"
+  | ^"pbe0"
+  | ^"b3lyp"
+  | ^"hse03"
+  | ^"hse06"
+  | ^"rscan"
+}
+bs_write_eigenvalues = {^"bs_write_eigenvalues" ~ ":" ~ logical}

--- a/castep-param-io/src/parser/param.pest
+++ b/castep-param-io/src/parser/param.pest
@@ -17,7 +17,7 @@ string     =  { (!(NEWLINE | COMMENT) ~ ANY)* }
 rand_seed  =  { ^"rand_seed" ~ ":" ~ integer }
 param_file =  { param_item* }
 keyword    = @{ (ASCII_ALPHANUMERIC | "_")* }
-value      = @{ EOI | logical | real | pos_integer | integer | string }
+value      = @{ string }
 kv_pair    =  { (keyword ~ WHITESPACE* ~ ":" ~ WHITESPACE* ~ value) }
 param_item =  { kv_pair | stop }
 
@@ -133,8 +133,8 @@ force_constant_units = {
   | ^"dyne/cm"
 }
 
-frequency_unit          = { ^"frequency_unit" ~ ":" ~ frequency_units }
-frequency_units         = {
+frequency_unit             = { ^"frequency_unit" ~ ":" ~ frequency_units }
+frequency_units            = {
     ^"ha"
   | ^"mha"
   | ^"ev"
@@ -152,15 +152,15 @@ frequency_units         = {
   | ^"cm-1"
   | ^"k"
 }
-inv_length_unit         = { ^"inv_length_unit" ~ ":" ~ inv_length_units }
-inv_length_units        = {
+inv_length_unit            = { ^"inv_length_unit" ~ ":" ~ inv_length_units }
+inv_length_units           = {
     ^"1/"
   | ^"1/m"
   | ^"1/nm"
   | ^"1/ang"
 }
-length_unit             = { ^"length_unit" ~ ":" ~ length_units }
-length_units            = {
+length_unit                = { ^"length_unit" ~ ":" ~ length_units }
+length_units               = {
     ^"bohr"
   | ^"a0"
   | ^"m"
@@ -168,15 +168,15 @@ length_units            = {
   | ^"nm"
   | ^"ang"
 }
-mass_unit               = { ^"mass_unit" ~ ":" ~ mass_units }
-mass_units              = {
+mass_unit                  = { ^"mass_unit" ~ ":" ~ mass_units }
+mass_units                 = {
     ^"me"
   | ^"amu"
   | ^"kg"
   | ^"g"
 }
-pressure_unit           = { ^"pressure_unit" ~ ":" ~ pressure_units }
-pressure_units          = {
+pressure_unit              = { ^"pressure_unit" ~ ":" ~ pressure_units }
+pressure_units             = {
     ^"hartree/bohr**3"
   | ^"ev/ang**3"
   | ^"pa"
@@ -186,8 +186,8 @@ pressure_units          = {
   | ^"bar"
   | ^"mbar"
 }
-time_unit               = { ^"time_unit" ~ ":" ~ time_units }
-time_units              = {
+time_unit                  = { ^"time_unit" ~ ":" ~ time_units }
+time_units                 = {
     ^"aut"
   | ^"s"
   | ^"ms"
@@ -196,8 +196,8 @@ time_units              = {
   | ^"ps"
   | ^"fs"
 }
-velocity_unit           = { ^"velocity_unit" ~ ":" ~ velocity_units }
-velocity_units          = {
+velocity_unit              = { ^"velocity_unit" ~ ":" ~ velocity_units }
+velocity_units             = {
     ^"auv"
   | ^"ang/ps"
   | ^"ang/fs"
@@ -205,42 +205,42 @@ velocity_units          = {
   | ^"bohr/fs"
   | ^"m/s"
 }
-volume_unit             = { ^"volume_unit" ~ ":" ~ volume_units }
-volume_units            = {
+volume_unit                = { ^"volume_unit" ~ ":" ~ volume_units }
+volume_units               = {
     ^"bohr**3"
   | ^"m**3"
   | ^"cm**3"
   | ^"nm**3"
   | ^"ang**3"
 }
-pspot_beta_phi_type     = { ^"pspot_beta_phi_type" ~ ":" ~ pspot_beta_phi_types }
-pspot_beta_phi_types    = {
+pspot_beta_phi_type        = { ^"pspot_beta_phi_type" ~ ":" ~ pspot_beta_phi_types }
+pspot_beta_phi_types       = {
     ^"reciprocal"
   | ^"real"
 }
-pspot_nonlocal_type     = { ^"pspot_nonlocal_type" ~ ":" ~ pspot_nonlocal_types }
-pspot_nonlocal_types    = {
+pspot_nonlocal_type        = { ^"pspot_nonlocal_type" ~ ":" ~ pspot_nonlocal_types }
+pspot_nonlocal_types       = {
     ^"reciprocal"
   | ^"real"
 }
-relativistic_treatment  = { ^"relativistic_treatment" ~ ":" ~ relativistic_treatments }
-relativistic_treatments = {
+relativistic_treatment     = { ^"relativistic_treatment" ~ ":" ~ relativistic_treatments }
+relativistic_treatments    = {
     ^"schroedinger"
   | ^"zora"
   | ^"koelling-harmon"
   | ^"dirac"
 }
-bs_eigenvalue_tol       = { ^"bs_eigenvalue_tol" ~ ":" ~ real ~ bs_eigenvalue_tol_unit }
-bs_eigenvalue_tol_unit  = { energy_units? }
-bs_max_cg_steps         = { ^"bs_max_cg_steps" ~ ":" ~ pos_integer }
-bs_max_iter             = { ^"bs_max_iter" ~ ":" ~ pos_integer }
-bs_nbands               = { ^"bs_nbands" ~ ":" ~ pos_integer }
-bs_re_est_k_scrn        = { ^"bs_re_est_k_scrn" ~ ":" ~ logical }
-bs_extra_bands          = { bs_nextra_bands | bs_perc_extra_bands }
-bs_nextra_bands         = { ^"bs_nextra_bands" ~ ":" ~ pos_integer }
-bs_perc_extra_bands     = { ^"bs_perc_extra_bands" ~ ":" ~ real }
-bs_xc_functional        = { ^"bs_xc_functional" ~ ":" ~ bs_xc_functionals }
-bs_xc_functionals       = {
+bs_eigenvalue_tol          = { ^"bs_eigenvalue_tol" ~ ":" ~ real ~ bs_eigenvalue_tol_unit }
+bs_eigenvalue_tol_unit     = { energy_units? }
+bs_max_cg_steps            = { ^"bs_max_cg_steps" ~ ":" ~ pos_integer }
+bs_max_iter                = { ^"bs_max_iter" ~ ":" ~ pos_integer }
+bs_nbands                  = { ^"bs_nbands" ~ ":" ~ pos_integer }
+bs_re_est_k_scrn           = { ^"bs_re_est_k_scrn" ~ ":" ~ logical }
+bs_extra_bands             = { bs_nextra_bands | bs_perc_extra_bands }
+bs_nextra_bands            = { ^"bs_nextra_bands" ~ ":" ~ pos_integer }
+bs_perc_extra_bands        = { ^"bs_perc_extra_bands" ~ ":" ~ real }
+bs_xc_functional           = { ^"bs_xc_functional" ~ ":" ~ bs_xc_functionals }
+bs_xc_functionals          = {
     ^"SHF-LDA"
   | ^"HF-LDA"
   | ^"lda"
@@ -257,4 +257,37 @@ bs_xc_functionals       = {
   | ^"hse06"
   | ^"rscan"
 }
-bs_write_eigenvalues = {^"bs_write_eigenvalues" ~ ":" ~ logical}
+bs_write_eigenvalues       = { ^"bs_write_eigenvalues" ~ ":" ~ logical }
+basis_de_dloge             = { ^"basis_de_dloge" ~ ":" ~ real }
+basis_precision            = { ^"basis_precision" ~ ":" ~ basis_precisions }
+basis_precisions           = {
+    ^"Coarse"
+  | ^"Medium"
+  | ^"Fine"
+  | ^"Precise"
+  | ^"Extreme"
+}
+cut_off_energy             = { ^"cut_off_energy" ~ ":" ~ real }
+fine_gmax                  = { ^"fine_gmax" ~ ":" ~ real ~ fine_gmax_unit }
+fine_gmax_unit             = { inv_length_units? }
+fine_grid_scale            = { ^"fine_grid_scale" ~ ":" ~ real }
+finite_basis_corr          = { ^"finite_basis_corr" ~ ":" ~ finite_basis_corrs }
+finite_basis_corrs         = {
+    ^"0"
+  | ^"1"
+  | ^"2"
+}
+finite_basis_npoints       = { ^"finite_basis_npoints" ~ ":" ~ pos_integer }
+fixed_npw                  = { ^"fixed_npw" ~ ":" ~ logical }
+grid_scale                 = { ^"grid_scale" ~ ":" ~ real }
+finite_basis_spacing       = { ^"finite_basis_spacing" ~ ":" ~ real ~ finite_basis_spacing_units }
+finite_basis_spacing_units = { energy_units? }
+charge                     = { ^"charge" ~ ":" ~ real }
+nbands                     = { ^"nbands" ~ ":" ~ pos_integer }
+extra_bands                = { nextra_bands | perc_extra_bands }
+nextra_bands               = { ^"nextra_bands" ~ ":" ~ pos_integer }
+perc_extra_bands           = { ^"perc_extra_bands" ~ ":" ~ real }
+nelectrons                 = { ^"nelectrons" ~ ":" ~ real }
+nup                        = { ^"nup" ~ ":" ~ real }
+ndown                      = { ^"ndown" ~ ":" ~ real }
+spin                       = { ^"spin" ~ ":" ~ real }

--- a/src/cell_document/sections/species_characters/lcao.rs
+++ b/src/cell_document/sections/species_characters/lcao.rs
@@ -4,7 +4,7 @@ use castep_periodic_table::{data::ELEMENT_TABLE, element::ElementSymbol, element
 
 use crate::formatting::BlockDisplay;
 
-use super::SpeciesCharacter;
+use super::{SpeciesBlock, SpeciesCharacter, SpeciesEntry};
 
 #[derive(Debug, Clone)]
 pub struct SpeciesLCAOStatesBlock {
@@ -31,6 +31,18 @@ pub struct LCAOBasis {
     num_angular_momentum: u8,
 }
 
+impl SpeciesEntry for LCAOBasis {
+    type Item = u8;
+
+    fn element(&self) -> &ElementSymbol {
+        &self.element
+    }
+
+    fn item(&self) -> &Self::Item {
+        &self.num_angular_momentum
+    }
+}
+
 impl LCAOBasis {
     pub fn new(element: ElementSymbol, num_angular_momentum: u8) -> Self {
         Self {
@@ -46,6 +58,18 @@ impl SpeciesCharacter for LCAOBasis {
     fn from_element(element: ElementSymbol) -> Self::Output {
         let lcao = ELEMENT_TABLE.get_by_symbol(element).lcao();
         LCAOBasis::new(element, lcao)
+    }
+}
+
+impl SpeciesBlock for SpeciesLCAOStatesBlock {
+    type ItemOutput = LCAOBasis;
+
+    fn items(&self) -> &[Self::ItemOutput] {
+        &self.basis_sets
+    }
+
+    fn items_mut(&mut self) -> &mut Vec<Self::ItemOutput> {
+        &mut self.basis_sets
     }
 }
 

--- a/src/cell_document/sections/species_characters/mass.rs
+++ b/src/cell_document/sections/species_characters/mass.rs
@@ -7,11 +7,23 @@ use castep_periodic_table::{
 
 use crate::formatting::BlockDisplay;
 
-use super::SpeciesCharacter;
+use super::{SpeciesBlock, SpeciesCharacter, SpeciesEntry};
 
 #[derive(Debug, Clone)]
 pub struct SpeciesMassBlock {
     items: Vec<SpeciesMass>,
+}
+
+impl SpeciesBlock for SpeciesMassBlock {
+    type ItemOutput = SpeciesMass;
+
+    fn items(&self) -> &[Self::ItemOutput] {
+        &self.items
+    }
+
+    fn items_mut(&mut self) -> &mut Vec<Self::ItemOutput> {
+        &mut self.items
+    }
 }
 
 impl SpeciesMassBlock {
@@ -32,6 +44,18 @@ impl SpeciesMassBlock {
 pub struct SpeciesMass {
     element: ElementSymbol,
     mass: f64,
+}
+
+impl SpeciesEntry for SpeciesMass {
+    type Item = f64;
+
+    fn element(&self) -> &ElementSymbol {
+        &self.element
+    }
+
+    fn item(&self) -> &Self::Item {
+        &self.mass
+    }
 }
 
 impl SpeciesMass {

--- a/src/cell_document/sections/species_characters/mod.rs
+++ b/src/cell_document/sections/species_characters/mod.rs
@@ -12,3 +12,15 @@ pub trait SpeciesCharacter {
     type Output;
     fn from_element(element: ElementSymbol) -> Self::Output;
 }
+
+pub trait SpeciesBlock {
+    type ItemOutput: SpeciesEntry;
+    fn items(&self) -> &[Self::ItemOutput];
+    fn items_mut(&mut self) -> &mut Vec<Self::ItemOutput>;
+}
+
+pub trait SpeciesEntry {
+    type Item;
+    fn element(&self) -> &ElementSymbol;
+    fn item(&self) -> &Self::Item;
+}

--- a/src/cell_document/sections/species_characters/potentials.rs
+++ b/src/cell_document/sections/species_characters/potentials.rs
@@ -4,7 +4,7 @@ use castep_periodic_table::{data::ELEMENT_TABLE, element::ElementSymbol, element
 
 use crate::formatting::BlockDisplay;
 
-use super::SpeciesCharacter;
+use super::{SpeciesBlock, SpeciesCharacter, SpeciesEntry};
 
 #[derive(Debug, Clone)]
 pub struct SpeciesPot {
@@ -12,9 +12,33 @@ pub struct SpeciesPot {
     pot_file: String,
 }
 
+impl SpeciesEntry for SpeciesPot {
+    type Item = String;
+
+    fn element(&self) -> &ElementSymbol {
+        &self.element
+    }
+
+    fn item(&self) -> &Self::Item {
+        &self.pot_file
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SpeciesPotBlock {
     items: Vec<SpeciesPot>,
+}
+
+impl SpeciesBlock for SpeciesPotBlock {
+    type ItemOutput = SpeciesPot;
+
+    fn items(&self) -> &[Self::ItemOutput] {
+        &self.items
+    }
+
+    fn items_mut(&mut self) -> &mut Vec<Self::ItemOutput> {
+        &mut self.items
+    }
 }
 
 impl SpeciesPotBlock {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use cell_document::{
     params::{CastepParams, CastepParamsBuilder, CastepTask, EnergyCutoff, EnergyCutoffError},
     to_cell_document,
     units::length_units::*,
+    CellDocument,
 };
 pub use keywords::{
     DocumentSections, KPointKeywords, KeywordType, LatticeBlockType, PositionsKeywords,

--- a/src/parsing/cell_parser.rs
+++ b/src/parsing/cell_parser.rs
@@ -50,6 +50,7 @@ impl CellParser<'_> {
                     KeywordType::Block(_) => {
                         get_block_data(&mut self.input)
                             .map_err(|_| CellParseError::GetBlockDataFailure)?;
+                        #[cfg(debug_assertions)]
                         dbg!(&self.input);
                     }
                     KeywordType::Field(field_kw) => {

--- a/src/parsing/helpers/fields/mod.rs
+++ b/src/parsing/helpers/fields/mod.rs
@@ -1,15 +1,15 @@
-use winnow::{token::take_till, PResult, Parser};
+use winnow::{token::take_till, ModalResult, Parser};
 
 use super::{effective_line, KeywordType};
 
 /// When it is "keyword : value"
-pub fn field_name<'s>(input: &mut &'s str) -> PResult<KeywordType<'s>> {
+pub fn field_name<'s>(input: &mut &'s str) -> ModalResult<KeywordType<'s>> {
     take_till(0.., |c| c == ' ' || c == ':')
         .map(|s: &str| KeywordType::Field(s.trim()))
         .parse_next(input)
 }
 
-pub fn get_field_data(input: &mut &str) -> PResult<String> {
+pub fn get_field_data(input: &mut &str) -> ModalResult<String> {
     effective_line
         .map(|s| s.replace(':', "").trim_start().to_string())
         .parse_next(input)

--- a/src/parsing/helpers/keywords/ionic_positions.rs
+++ b/src/parsing/helpers/keywords/ionic_positions.rs
@@ -8,7 +8,7 @@ use winnow::{
     combinator::{alt, preceded},
     error::{ContextError, StrContext},
     token::take_till,
-    PResult, Parser,
+    ModalResult, Parser,
 };
 
 use crate::cell_document::units::ParsableUnit;
@@ -21,19 +21,19 @@ use crate::{
     parsing::CellParseError,
 };
 
-fn assign_positions_frac<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+fn assign_positions_frac<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     Caseless("positions_frac")
         .map(|_| DocumentSections::IonicPositions(PositionsKeywords::POSITIONS_FRAC))
         .parse_next(input)
 }
 
-fn assign_positions_abs<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+fn assign_positions_abs<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     Caseless("positions_abs")
         .map(|_| DocumentSections::IonicPositions(PositionsKeywords::POSITIONS_ABS))
         .parse_next(input)
 }
 
-fn parse_mixture(input: &mut &str) -> PResult<Mixture> {
+fn parse_mixture(input: &mut &str) -> ModalResult<Mixture> {
     preceded(space1, Caseless("mixture")).parse_next(input)?;
     take_till(0.., AsChar::is_dec_digit).parse_next(input)?;
     if let Ok((id, _, val)) =
@@ -48,11 +48,11 @@ fn parse_mixture(input: &mut &str) -> PResult<Mixture> {
     }
 }
 
-pub fn assign_positions_type<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_positions_type<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((assign_positions_frac, assign_positions_abs)).parse_next(input)
 }
 
-fn parse_line_of_position(input: &mut &str) -> PResult<IonicPosition> {
+fn parse_line_of_position(input: &mut &str) -> ModalResult<IonicPosition> {
     let symbol = preceded(space0, alt((alpha1, digit1)))
         .map(|s| {
             ElementSymbol::from_str(s).map_err(|_| ErrMode::Cut(ContextError::<StrContext>::new()))

--- a/src/parsing/helpers/keywords/kpoint/assignments.rs
+++ b/src/parsing/helpers/keywords/kpoint/assignments.rs
@@ -1,14 +1,14 @@
-use winnow::{ascii::Caseless, combinator::alt, PResult, Parser};
+use winnow::{ascii::Caseless, combinator::alt, ModalResult, Parser};
 
 use crate::keywords::{DocumentSections, KPointKeywords};
 
-pub fn assign_kpoint_list_block<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_kpoint_list_block<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((Caseless("kpoint_list"), Caseless("kpoints_list")))
         .map(|_| DocumentSections::KPoint(KPointKeywords::KPOINT_LIST))
         .parse_next(input)
 }
 
-pub fn assign_bs_kpoint_list_block<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_bs_kpoint_list_block<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((
         Caseless("bs_kpoint_list"),
         Caseless("bs_kpoints_list"),
@@ -19,13 +19,13 @@ pub fn assign_bs_kpoint_list_block<'s>(input: &mut &'s str) -> PResult<DocumentS
     .parse_next(input)
 }
 
-pub fn assign_kpoint_mp_grid_field<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_kpoint_mp_grid_field<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((Caseless("kpoint_mp_grid"), Caseless("kpoints_mp_grid")))
         .map(|_| DocumentSections::KPoint(KPointKeywords::KPOINT_MP_GRID))
         .parse_next(input)
 }
 
-pub fn assign_kpoint_mp_spacing_field<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_kpoint_mp_spacing_field<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((
         Caseless("kpoint_mp_spacing"),
         Caseless("kpoints_mp_spacing"),
@@ -34,7 +34,7 @@ pub fn assign_kpoint_mp_spacing_field<'s>(input: &mut &'s str) -> PResult<Docume
     .parse_next(input)
 }
 
-pub fn assign_kpoint_mp_offset_field<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_kpoint_mp_offset_field<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((Caseless("kpoint_mp_offset"), Caseless("kpoints_mp_offset")))
         .map(|_| DocumentSections::KPoint(KPointKeywords::KPOINT_MP_OFFSET))
         .parse_next(input)
@@ -42,7 +42,7 @@ pub fn assign_kpoint_mp_offset_field<'s>(input: &mut &'s str) -> PResult<Documen
 
 pub fn assign_kpoint_bs_path_spacing_field<'s>(
     input: &mut &'s str,
-) -> PResult<DocumentSections<'s>> {
+) -> ModalResult<DocumentSections<'s>> {
     alt((
         Caseless("bs_kpoint_path_spacing"),
         Caseless("spectral_kpoint_path_spacing"),
@@ -53,7 +53,7 @@ pub fn assign_kpoint_bs_path_spacing_field<'s>(
     .parse_next(input)
 }
 
-pub fn assign_bs_kpoint_path_block<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_bs_kpoint_path_block<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((Caseless("bs_kpoint_path"), Caseless("spectral_kpoint_path")))
         .map(|_| DocumentSections::KPoint(KPointKeywords::SPECTRAL_KPOINT_PATH))
         .parse_next(input)

--- a/src/parsing/helpers/keywords/kpoint/block_parsers.rs
+++ b/src/parsing/helpers/keywords/kpoint/block_parsers.rs
@@ -1,7 +1,7 @@
 use winnow::{
     error::{AddContext, ContextError, ErrMode, StrContext, StrContextValue},
     stream::Stream,
-    PResult,
+    ModalResult,
 };
 
 use crate::{
@@ -10,13 +10,13 @@ use crate::{
     CellParseError,
 };
 
-fn parse_line_of_kpoint(input: &mut &str) -> PResult<[f64; 4]> {
+fn parse_line_of_kpoint(input: &mut &str) -> ModalResult<[f64; 4]> {
     let err_context = ContextError::<StrContext>::new().add_context(
         input,
         &input.checkpoint(),
         StrContext::Expected(StrContextValue::Description("Incorrect input: not `f64`")),
     );
-    let kpoint: PResult<Vec<f64>> = input
+    let kpoint: ModalResult<Vec<f64>> = input
         .split_whitespace()
         .map(|s| {
             s.parse::<f64>()
@@ -28,13 +28,13 @@ fn parse_line_of_kpoint(input: &mut &str) -> PResult<[f64; 4]> {
         .map_err(|_| ErrMode::Backtrack(err_context))
 }
 
-fn parse_line_of_kpoint_path(input: &mut &str) -> PResult<[f64; 3]> {
+fn parse_line_of_kpoint_path(input: &mut &str) -> ModalResult<[f64; 3]> {
     let err_context = ContextError::<StrContext>::new().add_context(
         input,
         &input.checkpoint(),
         StrContext::Expected(StrContextValue::Description("Incorrect input: not `f64`")),
     );
-    let kpoint: PResult<Vec<f64>> = input
+    let kpoint: ModalResult<Vec<f64>> = input
         .split_whitespace()
         .map(|s| {
             s.parse::<f64>()
@@ -52,7 +52,7 @@ pub fn parse_kpoint_list(input: &mut &str) -> Result<KpointSettings, CellParseEr
         .lines()
         .filter(|s| !s.is_empty())
         .map(|mut line| parse_line_of_kpoint(&mut line))
-        .collect::<PResult<Vec<[f64; 4]>>>()
+        .collect::<ModalResult<Vec<[f64; 4]>>>()
         .map_err(|_| CellParseError::Invalid)?;
     Ok(KpointSettings::List(KpointListBlock::new(
         KpointTask::SCF,
@@ -66,7 +66,7 @@ pub fn parse_bs_kpoint_list(input: &mut &str) -> Result<NCKpointSettings, CellPa
         .lines()
         .filter(|s| !s.is_empty())
         .map(|mut line| parse_line_of_kpoint(&mut line))
-        .collect::<PResult<Vec<[f64; 4]>>>()
+        .collect::<ModalResult<Vec<[f64; 4]>>>()
         .map_err(|_| CellParseError::Invalid)?;
     Ok(NCKpointSettings::List(KpointListBlock::new(
         KpointTask::Spectral,

--- a/src/parsing/helpers/keywords/kpoint/mod.rs
+++ b/src/parsing/helpers/keywords/kpoint/mod.rs
@@ -1,4 +1,4 @@
-use winnow::{combinator::alt, PResult, Parser};
+use winnow::{combinator::alt, ModalResult, Parser};
 
 use crate::keywords::DocumentSections;
 
@@ -16,7 +16,7 @@ use assignments::{
 pub use block_parsers::{parse_bs_kpoint_list, parse_bs_kpoint_path, parse_kpoint_list};
 pub use field_parsers::{parse_kpoint_mp_grid_field, parse_kpoint_mp_spacing_field};
 
-pub fn assign_kpoint_block_type<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_kpoint_block_type<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((
         assign_kpoint_list_block,
         assign_bs_kpoint_list_block,
@@ -25,7 +25,7 @@ pub fn assign_kpoint_block_type<'s>(input: &mut &'s str) -> PResult<DocumentSect
     .parse_next(input)
 }
 
-pub fn assign_kpoint_field_settings<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_kpoint_field_settings<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((
         assign_kpoint_mp_grid_field,
         assign_kpoint_mp_spacing_field,

--- a/src/parsing/helpers/keywords/lattice.rs
+++ b/src/parsing/helpers/keywords/lattice.rs
@@ -1,4 +1,4 @@
-use winnow::{ascii::Caseless, combinator::alt, PResult, Parser};
+use winnow::{ascii::Caseless, combinator::alt, ModalResult, Parser};
 
 use crate::{
     cell_document::{
@@ -9,19 +9,19 @@ use crate::{
     LengthUnit,
 };
 
-fn assign_lattice_cart<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+fn assign_lattice_cart<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     Caseless("lattice_cart")
         .map(|_| DocumentSections::CellLatticeVectors(LatticeBlockType::LATTICE_CART))
         .parse_next(input)
 }
 
-fn assign_lattice_abc<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+fn assign_lattice_abc<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     Caseless("lattice_abc")
         .map(|_| DocumentSections::CellLatticeVectors(LatticeBlockType::LATTICE_ABC))
         .parse_next(input)
 }
 
-pub fn assign_lattice_type<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_lattice_type<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     alt((assign_lattice_abc, assign_lattice_cart)).parse_next(input)
 }
 

--- a/src/parsing/helpers/keywords/mod.rs
+++ b/src/parsing/helpers/keywords/mod.rs
@@ -1,4 +1,4 @@
-use winnow::{combinator::rest, PResult, Parser};
+use winnow::{token::rest, ModalResult, Parser};
 
 use crate::keywords::{DocumentSections, KeywordType};
 
@@ -8,12 +8,12 @@ pub(crate) mod lattice;
 pub(crate) mod species;
 // TODO: More sections
 
-pub fn any_block<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn any_block<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     rest.map(|s: &str| DocumentSections::Misc(KeywordType::Block(s)))
         .parse_next(input)
 }
 
-pub fn any_field<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn any_field<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     rest.map(|s: &str| DocumentSections::Misc(KeywordType::Field(s)))
         .parse_next(input)
 }

--- a/src/parsing/helpers/keywords/species/lcao_states.rs
+++ b/src/parsing/helpers/keywords/species/lcao_states.rs
@@ -1,7 +1,7 @@
 use winnow::{
     ascii::{digit1, space1},
     combinator::preceded,
-    PResult, Parser,
+    ModalResult, Parser,
 };
 
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
 
 use super::parse_element;
 
-fn parse_line_of_lcao(input: &mut &str) -> PResult<LCAOBasis> {
+fn parse_line_of_lcao(input: &mut &str) -> ModalResult<LCAOBasis> {
     let element = parse_element(input)?;
     let lcao_states = preceded(space1, digit1)
         .map(|v: &str| v.parse::<u8>().expect("Fail to parse `u8`"))
@@ -28,7 +28,7 @@ pub fn parse_species_lcao_block(
         .lines()
         .filter(|s| !s.is_empty())
         .map(|mut s| parse_line_of_lcao(&mut s))
-        .collect::<PResult<Vec<LCAOBasis>>>()
+        .collect::<ModalResult<Vec<LCAOBasis>>>()
         .map_err(|_| CellParseError::Invalid)?;
     Ok(SpeciesLCAOStatesBlock::new(lcao_items))
 }

--- a/src/parsing/helpers/keywords/species/mass.rs
+++ b/src/parsing/helpers/keywords/species/mass.rs
@@ -1,7 +1,7 @@
 use winnow::{
     ascii::{float, space1},
     combinator::preceded,
-    PResult, Parser,
+    ModalResult, Parser,
 };
 
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
 
 use super::parse_element;
 
-fn parse_line_of_mass(input: &mut &str) -> PResult<SpeciesMass> {
+fn parse_line_of_mass(input: &mut &str) -> ModalResult<SpeciesMass> {
     let element = parse_element(input)?;
     let mass: f64 = preceded(space1, float).parse_next(input)?;
     Ok(SpeciesMass::new(element, mass))
@@ -24,7 +24,7 @@ pub fn parse_species_mass_block(input: &mut &str) -> Result<SpeciesMassBlock, Ce
         .lines()
         .filter(|s| !s.is_empty())
         .map(|mut s| parse_line_of_mass(&mut s))
-        .collect::<PResult<Vec<SpeciesMass>>>()
+        .collect::<ModalResult<Vec<SpeciesMass>>>()
         .map_err(|_| CellParseError::Invalid)?;
     Ok(SpeciesMassBlock::new(mass_items))
 }

--- a/src/parsing/helpers/keywords/species/mod.rs
+++ b/src/parsing/helpers/keywords/species/mod.rs
@@ -4,7 +4,7 @@ use castep_periodic_table::element::ElementSymbol;
 use winnow::{
     ascii::{alpha1, digit1, space0, Caseless},
     combinator::{alt, preceded},
-    PResult, Parser,
+    ModalResult, Parser,
 };
 
 use crate::keywords::{DocumentSections, SpeciesKeywords};
@@ -17,7 +17,7 @@ pub use lcao_states::parse_species_lcao_block;
 pub use mass::parse_species_mass_block;
 pub use potentials::parse_species_pot_block;
 
-pub fn assign_species_type<'s>(input: &mut &'s str) -> PResult<DocumentSections<'s>> {
+pub fn assign_species_type<'s>(input: &mut &'s str) -> ModalResult<DocumentSections<'s>> {
     let assignment = |tag_name: &'s str, keyword: SpeciesKeywords| {
         Caseless(tag_name).map(move |_| DocumentSections::Species(keyword))
     };
@@ -29,7 +29,7 @@ pub fn assign_species_type<'s>(input: &mut &'s str) -> PResult<DocumentSections<
     .parse_next(input)
 }
 
-fn parse_element(input: &mut &str) -> PResult<ElementSymbol> {
+fn parse_element(input: &mut &str) -> ModalResult<ElementSymbol> {
     alt((preceded(space0, alpha1), preceded(space0, digit1)))
         .map(|s| {
             ElementSymbol::from_str(s).expect("Error in input element symbol or atomic number")

--- a/src/parsing/helpers/keywords/species/potentials.rs
+++ b/src/parsing/helpers/keywords/species/potentials.rs
@@ -1,7 +1,7 @@
 use winnow::{
     ascii::{space1, till_line_ending},
     combinator::preceded,
-    PResult, Parser,
+    ModalResult, Parser,
 };
 
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
 
 use super::parse_element;
 
-fn parse_line_of_pot(input: &mut &str) -> PResult<SpeciesPot> {
+fn parse_line_of_pot(input: &mut &str) -> ModalResult<SpeciesPot> {
     let element = parse_element(input)?;
     let pot_file = preceded(space1, till_line_ending).parse_next(input)?;
     Ok(SpeciesPot::new(element, pot_file.to_string()))
@@ -24,7 +24,7 @@ pub fn parse_species_pot_block(input: &mut &str) -> Result<SpeciesPotBlock, Cell
         .lines()
         .filter(|s| !s.is_empty())
         .map(|mut s| parse_line_of_pot(&mut s))
-        .collect::<PResult<Vec<SpeciesPot>>>()
+        .collect::<ModalResult<Vec<SpeciesPot>>>()
         .map_err(|_| CellParseError::Invalid)?;
     Ok(SpeciesPotBlock::new(pot_items))
 }


### PR DESCRIPTION
- **Add access methods for species blocks and entries**
- **Add access methods for species blocks and entries**
- **Suppress dbg output in release build**
- **Estabilished the parser to data type framework.**
- **derived `FromPest` and `BuildFromPairs`**
- **Handle `STOP` correctly**
- **Implementing parser**
- **Implementing parser**
- **Solve how to deal with `Stop` in parsing the file**
- **Helper scripts to generate boilerplate codes**
- **Implementing parser for units**
- **Implemented parser for `BandStructure`**
- **Implemented parser for `ElectronicParam` and `BasisSet`**
- **Assistive scripts for boilerplate codes**
- **Upgrade `winnow` to `0.7.6`, replace deprecated usage of `PResult` to `ModalResult`**
